### PR TITLE
BTFS-714: Support dagreader for reed-solomon encoded dag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-ipld-format v0.0.2
 	github.com/ipfs/go-merkledag v0.2.3
+	github.com/klauspost/reedsolomon v1.9.2
 	github.com/multiformats/go-multihash v0.0.5
 	github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14 // indirect
 	github.com/smartystreets/assertions v1.0.0 // indirect

--- a/io/reed_solomon_dagreader.go
+++ b/io/reed_solomon_dagreader.go
@@ -1,0 +1,151 @@
+package io
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	rs "github.com/klauspost/reedsolomon"
+)
+
+// reedSolomonDagReader reads a dag by concurrently merging N shards
+// in a N/M encoded UnixFS dag file.
+// Due to reed solomon requiring N shards to exist, we cannot perform
+// stream Read or Seek on this reader.
+// Everything will be pre-filled in memory before supporting DagReader
+// operations from a []byte reader.
+type reedSolomonDagReader struct {
+	bytes.Buffer // for Reader, Seeker, and WriteTo
+}
+
+type nodeBufIndex struct {
+	b   *bytes.Buffer
+	i   int
+	err error
+}
+
+// A ReedSolomonDagReader wraps M DagReaders and reads N (data) out of
+// M (data + parity) concurrently to decode the original file shards for
+// the returned DagReader to use.
+func NewReedSolomonDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter,
+	numData, numParity, size uint64) (DagReader, error) {
+	totalShards := int(numData + numParity)
+	if totalShards != len(n.Links()) {
+		return nil, fmt.Errorf("number of links under node [%d] does not match set data + parity [%d]",
+			len(n.Links()), totalShards)
+	}
+
+	// Grab at least N nodes then we are ready for re-construction
+	// Timeout is set at upper caller level through context.Context
+	nodeBufChan := make(chan nodeBufIndex)
+	ctxWithCancel, cancel := context.WithCancel(ctx)
+	for i, link := range n.Links() {
+		go func(ctx context.Context, shardCID cid.Cid, index int) {
+			node, err := serv.Get(ctx, shardCID)
+			if err != nil {
+				nodeBufChan <- nodeBufIndex{nil, index, err}
+				return
+			}
+			dr, err := NewDagReader(ctx, n, serv)
+			if err != nil {
+				nodeBufChan <- nodeBufIndex{nil, index, err}
+				return
+			}
+			var b bytes.Buffer
+			_, err = io.Copy(&b, dr)
+			if err != nil {
+				nodeBufChan <- nodeBufIndex{nil, index, err}
+				return
+			}
+			nodeBufChan <- nodeBufIndex{&b, index, nil}
+		}(ctxWithCancel, link.Cid(), i)
+	}
+
+	// Context deadline is set so it should exit eventually
+	bufs := make(*bytes.Buffer, totalShards)
+	valid := 0
+	for _, nbi := range nodeBufChan {
+		if nbi.err != nil {
+			continue
+		}
+		bufs[nbi.i] = nbi.b
+		valid += 1
+		if valid == int(numData) {
+			// No need to get more nodes
+			cancel()
+			break
+		}
+	}
+	if valid < int(numData) {
+		return nil, fmt.Errorf("unable to obtain at least [%d] shards to join original file", numData)
+	}
+
+	// Check if we already have everything
+	dataValid := true
+	for i := 0; i < numData; i++ {
+		if bufs[i] == nil {
+			dataValid = false
+			break
+		}
+	}
+
+	// Reconstruct if missing some data shards
+	if !dataValid {
+		// Create rs stream
+		rss, err := rs.NewStreamC(int(numData), int(numParity), true, true)
+		if err != nil {
+			return nil, err
+		}
+
+		// Now reconstruct
+		valid := make(io.Reader, totalShards)
+		fill := make(io.Writer, totalShards)
+		// Only fill the missing data shards
+		for i := 0; i < numData; i++ {
+			b := bufs[i]
+			if b != nil {
+				valid[i] = bytes.NewReader(b.Bytes())
+			} else {
+				b = &bytes.Buffer{}
+				bufs[i] = b
+				fill[i] = b
+			}
+		}
+		err = rss.Reconstruct(valid, fill)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rsdr := &reedSolomonDagReader{}
+	// Now join to have the final combined file reader
+	shards := make(io.Reader, totalShards)
+	for i := 0; i < numData; i++ {
+		shards[i] = bytes.NewReader(b.Bytes())
+	}
+	err = rss.Join(&rsdr.BytesBuffer, shards, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return rsdr, nil
+}
+
+// Size returns the total size of the data from the decoded DAG structured file
+// using reed solomon algorithm.
+func (rsdr *reedSolomonDagReader) Size() uint64 {
+	return uint64(rsdr.Len())
+}
+
+// Close has no effect since the underlying reader is a buffer.
+func (rsdr *reedSolomonDagReader) Close() error {
+	return nil
+}
+
+// CtxReadFull is just a Read since there is no context for buffer.
+func (rsdr *reedSolomonDagReader) CtxReadFull(ctx context.Context, out []byte) (int, error) {
+	return rsdr.Read(out)
+}

--- a/io/reed_solomon_dagreader_test.go
+++ b/io/reed_solomon_dagreader_test.go
@@ -1,0 +1,42 @@
+package io
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	testu "github.com/TRON-US/go-unixfs/test"
+)
+
+const (
+	testRsDefaultNumData   = 10
+	testRsDefaultNumParity = 20
+)
+
+func TestReedSolomonRead(t *testing.T) {
+	dserv := testu.GetDAGServ()
+	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
+		testu.UseReedSolomon(testRsDefaultNumData, testRsDefaultNumParity))
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	reader, err := NewReedSolomonDagReader(ctx, node, dserv,
+		testRsDefaultNumData, testRsDefaultNumParity, uint64(len(inbuf)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outbuf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(inbuf, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TODO: Currently we don't test the rest of the functions since everything
+// is performed against a standard bytes.Buffer (implementation).
+// Eventually, for completeness, we should.


### PR DESCRIPTION
- Support reed solomon encoded dag by parsing the sharded dags in separate dagreaders
- The underlying "dagreader" is backed by a bytes.Reader to support all interface methods
- The `NewReedSolomonDagReader` function does not use any real streaming tricks to reduce memory usage - this will be addressed in BTFS-910 (streaming solutions)
- Only basic read unit test for now
- Currently, since metadata is not fully ready yet, we will pass the reed solomon parameters (data, shard, size) into the dagreader constructor directly (this will be passed in from the go-btfs command)