### PR TITLE
BTFS-712: Support reading reed solomon files from btfs cat/get

### DIFF
--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -2,6 +2,7 @@ package unixfile
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	ft "github.com/TRON-US/go-unixfs"
@@ -238,21 +239,21 @@ func skipMetadataIfExists(ctx context.Context, nd ipld.Node, ds ipld.DAGService)
 
 	// Return user data and metadata if first child is of type TTokenMeta.
 	if nd.Links() != nil && len(nd.Links()) >= 2 {
-		childen, err := ft.GetChildrenForDagWithMeta(ctx, nd, ds)
+		children, err := ft.GetChildrenForDagWithMeta(ctx, nd, ds)
 		if err != nil {
 			return nil, nil, err
 		}
-		if childen == nil {
+		if children == nil {
 			return nd, nil, nil
 		}
 		metaNode, err := ft.FSNodeFromBytes(children[0].(*dag.ProtoNode).Data())
 		if err != nil {
 			return nil, nil, err
 		}
-		return childen[1], metaNode.Data(), nil
+		return children[1], metaNode.Data(), nil
 	}
 
-	return nd, nil
+	return nd, nil, nil
 }
 
 var _ files.Directory = &ufsDirectory{}

--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -199,7 +199,8 @@ func NewUnixfsFile(ctx context.Context, dserv ipld.DAGService, nd ipld.Node, met
 			return nil, err
 		}
 		if rsMeta.NumData > 0 && rsMeta.NumParity > 0 && rsMeta.FileSize > 0 {
-			dr, err = uio.NewReedSolomonDagReader(ctx, nd, dserv,
+			// Always read from the actual dag root for reed solomon
+			dr, err = uio.NewReedSolomonDagReader(ctx, newNode, dserv,
 				rsMeta.NumData, rsMeta.NumParity, rsMeta.FileSize)
 			if err != nil {
 				return nil, err

--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -1,0 +1,111 @@
+package unixfile
+
+import (
+	"context"
+	//"fmt"
+	"io/ioutil"
+	"testing"
+
+	testu "github.com/TRON-US/go-unixfs/test"
+
+	files "github.com/TRON-US/go-btfs-files"
+)
+
+func TestUnixFsFileRead(t *testing.T) {
+	dserv := testu.GetDAGServ()
+	inbuf, node := testu.GetRandomNode(t, dserv, 1024, testu.UseProtoBufLeaves)
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	n, err := NewUnixfsFile(ctx, dserv, node, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := files.ToFile(n)
+
+	outbuf, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(inbuf, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnixFsFileReadWithMetadata(t *testing.T) {
+	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}`)
+	dserv := testu.GetDAGServ()
+	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
+		testu.UseBalancedWithMetadata(inputMeta, 512))
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	// Read but do not display meta
+	n, err := NewUnixfsFile(ctx, dserv, node, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := files.ToFile(n)
+
+	outbuf, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(inbuf, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read both data and metadata
+	n, err = NewUnixfsFile(ctx, dserv, node, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file = files.ToFile(n)
+
+	outbuf, err = ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(append(inputMeta, inbuf...), outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnixFsFileReedSolomonRead(t *testing.T) {
+	dserv := testu.GetDAGServ()
+	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
+		testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, nil, 0))
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	// Pre-compute reed solomon metadata
+	//rsMeta := []byte(fmt.Sprintf(`{"NumData":%d,"NumParity":%d,"FileSize":%d}`,
+	//testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf))))
+
+	// Read but do not display meta
+	n, err := NewUnixfsFile(ctx, dserv, node, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := files.ToFile(n)
+
+	outbuf, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(inbuf, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -87,10 +87,6 @@ func TestUnixFsFileReedSolomonRead(t *testing.T) {
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 
-	// Pre-compute reed solomon metadata
-	//rsMeta := []byte(fmt.Sprintf(`{"NumData":%d,"NumParity":%d,"FileSize":%d}`,
-	//testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf))))
-
 	// Read but do not display meta
 	n, err := NewUnixfsFile(ctx, dserv, node, false)
 	if err != nil {

--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -33,6 +33,12 @@ func TestUnixFsFileRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Should have no metadata
+	_, err = NewUnixfsFile(ctx, dserv, node, true)
+	if err == nil {
+		t.Fatal("no metadata error should be returned")
+	}
 }
 
 func TestUnixFsFileReadWithMetadata(t *testing.T) {
@@ -43,7 +49,7 @@ func TestUnixFsFileReadWithMetadata(t *testing.T) {
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 
-	// Read but do not display meta
+	// Read only data
 	n, err := NewUnixfsFile(ctx, dserv, node, false)
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +67,7 @@ func TestUnixFsFileReadWithMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Read both data and metadata
+	// Read only metadata
 	n, err = NewUnixfsFile(ctx, dserv, node, true)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +80,7 @@ func TestUnixFsFileReadWithMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testu.ArrComp(append(inputMeta, inbuf...), outbuf)
+	err = testu.ArrComp(inputMeta, outbuf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,12 +88,14 @@ func TestUnixFsFileReadWithMetadata(t *testing.T) {
 
 func TestUnixFsFileReedSolomonRead(t *testing.T) {
 	dserv := testu.GetDAGServ()
-	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
-		testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, nil, 0))
+
+	rsOpts, rsMeta := testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity,
+		1024, nil, 512)
+	inbuf, node := testu.GetRandomNode(t, dserv, 1024, rsOpts)
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 
-	// Read but do not display meta
+	// Read only joined data
 	n, err := NewUnixfsFile(ctx, dserv, node, false)
 	if err != nil {
 		t.Fatal(err)
@@ -101,6 +109,71 @@ func TestUnixFsFileReedSolomonRead(t *testing.T) {
 	}
 
 	err = testu.ArrComp(inbuf, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read only reed solomon fixed metadata
+	n, err = NewUnixfsFile(ctx, dserv, node, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file = files.ToFile(n)
+
+	outbuf, err = ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(rsMeta, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnixFsFileReedSolomonMetadataRead(t *testing.T) {
+	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}`)
+	dserv := testu.GetDAGServ()
+
+	rsOpts, rsMeta := testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity,
+		1024, inputMeta, 512)
+	inbuf, node := testu.GetRandomNode(t, dserv, 1024, rsOpts)
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	// Read only joined data
+	n, err := NewUnixfsFile(ctx, dserv, node, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file := files.ToFile(n)
+
+	outbuf, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(inbuf, outbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read reed solomon fixed metadata + custom metadata
+	n, err = NewUnixfsFile(ctx, dserv, node, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file = files.ToFile(n)
+
+	outbuf, err = ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testu.ArrComp(testu.ExtendMetaBytes(rsMeta, inputMeta), outbuf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/TRON-US/go-unixfs
 
 require (
 	github.com/Stebalien/go-bitfield v0.0.1
-	github.com/TRON-US/go-btfs-chunker v0.2.2
+	github.com/TRON-US/go-btfs-chunker v0.2.3
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/gogo/protobuf v1.2.1
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOv
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
-github.com/TRON-US/go-btfs-chunker v0.2.0 h1:dp80UzRmUFzDDDt4nqo2STGVh5I4jDQJRYJYtRGulSo=
-github.com/TRON-US/go-btfs-chunker v0.2.0/go.mod h1:6wFL7KgEumsn7R7IGFZZhOGIHxA/YkA4RdfR553M3Fk=
-github.com/TRON-US/go-btfs-chunker v0.2.2 h1:aiLDsiM3X2Yy2jVo3EQYYEVkw57SThOUPTs0Ja5yPeA=
-github.com/TRON-US/go-btfs-chunker v0.2.2/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
+github.com/TRON-US/go-btfs-chunker v0.2.3 h1:ky/HsQY8UU+Mas3qXptwO9x3Pd2HWDDm+ycpS+NI9Js=
+github.com/TRON-US/go-btfs-chunker v0.2.3/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-files v0.1.1 h1:GuDIiWDM66bfhfxJy8+dBL4Cfbcp3iBp7pgHpKKCw8k=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -100,8 +98,6 @@ github.com/ipfs/go-ipfs-exchange-interface v0.0.1 h1:LJXIo9W7CAmugqI+uofioIpRb6r
 github.com/ipfs/go-ipfs-exchange-interface v0.0.1/go.mod h1:c8MwfHjtQjPoDyiy9cFquVtVHkO9b9Ob3FG91qJnWCM=
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1 h1:P56jYKZF7lDDOLx5SotVh5KFxoY6C81I1NSHW1FxGew=
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1/go.mod h1:WhHSFCVYX36H/anEKQboAzpUws3x7UeEGkzQc3iNkM0=
-github.com/ipfs/go-ipfs-files v0.0.3 h1:ME+QnC3uOyla1ciRPezDW0ynQYK2ikOh9OCKAEg4uUA=
-github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-posinfo v0.0.1 h1:Esoxj+1JgSjX0+ylc0hUmJCOv6V2vFoZiETLR6OtpRs=
 github.com/ipfs/go-ipfs-posinfo v0.0.1/go.mod h1:SwyeVP+jCwiDu0C313l/8jg6ZxM0qqtlt2a0vILTc1A=
 github.com/ipfs/go-ipfs-pq v0.0.1 h1:zgUotX8dcAB/w/HidJh1zzc1yFq6Vm8J7T2F4itj/RU=

--- a/io/reed_solomon_dagreader_test.go
+++ b/io/reed_solomon_dagreader_test.go
@@ -64,7 +64,7 @@ func TestReedSolomonWithMetadataRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mreader, err := NewDagReader(context.Background(), mnode, dserv)
+	mreader, err := NewDagReader(ctx, mnode, dserv)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/io/reed_solomon_dagreader_test.go
+++ b/io/reed_solomon_dagreader_test.go
@@ -8,20 +8,15 @@ import (
 	testu "github.com/TRON-US/go-unixfs/test"
 )
 
-const (
-	testRsDefaultNumData   = 10
-	testRsDefaultNumParity = 20
-)
-
 func TestReedSolomonRead(t *testing.T) {
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
-		testu.UseReedSolomon(testRsDefaultNumData, testRsDefaultNumParity, nil, 0))
+		testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, nil, 0))
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 
 	reader, err := NewReedSolomonDagReader(ctx, node, dserv,
-		testRsDefaultNumData, testRsDefaultNumParity, uint64(len(inbuf)))
+		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +37,7 @@ func TestReedSolomonWithMetadataRead(t *testing.T) {
 	dserv := testu.GetDAGServ()
 
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
-		testu.UseReedSolomon(testRsDefaultNumData, testRsDefaultNumParity, inputMdata, 512))
+		testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, inputMdata, 512))
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 
@@ -55,7 +50,7 @@ func TestReedSolomonWithMetadataRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	reader, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
-		testRsDefaultNumData, testRsDefaultNumParity, uint64(len(inbuf)))
+		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/utils.go
+++ b/test/utils.go
@@ -59,6 +59,11 @@ var (
 	UseBlake2b256     NodeOpts
 )
 
+const (
+	TestRsDefaultNumData   = 10
+	TestRsDefaultNumParity = 20
+)
+
 func UseBalancedWithMetadata(mdata []byte, chkSize uint64) NodeOpts {
 	return NodeOpts{Prefix: mdag.V0CidPrefix(), Balanced: true, metadata: mdata, chunkSize: chkSize}
 }

--- a/test/utils.go
+++ b/test/utils.go
@@ -68,10 +68,36 @@ func UseBalancedWithMetadata(mdata []byte, chkSize uint64) NodeOpts {
 	return NodeOpts{Prefix: mdag.V0CidPrefix(), Balanced: true, metadata: mdata, chunkSize: chkSize}
 }
 
-func UseReedSolomon(numData, numParity uint64, mdata []byte, chkSize uint64) NodeOpts {
-	return NodeOpts{Prefix: mdag.V0CidPrefix(), ReedSolomonEnabled: true,
-		rsNumData: numData, rsNumParity: numParity, metadata: mdata,
-		chunkSize: chkSize}
+func ReedSolomonMetaBytes(numData, numParity, fileSize uint64) []byte {
+	return []byte(fmt.Sprintf(`{"NumData":%d,"NumParity":%d,"FileSize":%d}`,
+		numData, numParity, fileSize))
+}
+
+func ExtendMetaBytes(existing []byte, extended []byte) []byte {
+	if existing != nil {
+		// Splice two meta json objects
+		if extended != nil {
+			return append(append(existing[:len(existing)-1], ','), extended[1:]...)
+		} else {
+			return existing
+		}
+	} else {
+		return extended
+	}
+}
+
+func UseReedSolomon(numData, numParity, fileSize uint64, mdata []byte, chkSize uint64) (NodeOpts, []byte) {
+	// Reed Solomon have intrinsic metadata, so must merge them
+	rsMeta := ReedSolomonMetaBytes(numData, numParity, fileSize)
+	metaBytes := ExtendMetaBytes(rsMeta, mdata)
+	return NodeOpts{
+		Prefix:             mdag.V0CidPrefix(),
+		ReedSolomonEnabled: true,
+		rsNumData:          numData,
+		rsNumParity:        numParity,
+		metadata:           metaBytes,
+		chunkSize:          chkSize,
+	}, rsMeta
 }
 
 func init() {


### PR DESCRIPTION
- Support auto-reading metadata of reed solomon file to read on btfs cat/get
- Add unit tests for NewUnixfsFile
- Changed `meta bool` param of NewUnixfsFile to only return data/meta depending on flag
- Fix some dagreader tests