### PR TITLE
BTFS-975: UnixFS metadata support for Trickle format

### DIFF
--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -55,7 +55,6 @@ import (
 	h "github.com/TRON-US/go-unixfs/importer/helpers"
 	pb "github.com/TRON-US/go-unixfs/pb"
 	ipld "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
 )
 
 // Layout builds a balanced DAG layout. In a balanced DAG of depth 1, leaf nodes
@@ -176,7 +175,7 @@ func Layout(db *h.DagBuilderHelper) (ipld.Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		root, err = attachMetadataDag(db, root, fileSize)
+		root, err = db.AttachMetadataDag(root, fileSize)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +195,7 @@ func layout(db *h.DagBuilderHelper, addMetaDag bool) (ipld.Node, error) {
 		// This works without Filestore support (`ProcessFileStore`).
 		// TODO: Why? Is there a test case missing?
 		if addMetaDag {
-			root, err = attachMetadataDag(db, root, 0)
+			root, err = db.AttachMetadataDag(root, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -236,7 +235,7 @@ func layout(db *h.DagBuilderHelper, addMetaDag bool) (ipld.Node, error) {
 
 	// Add token metadata DAG, if exists, as a child to the 'newRoot'.
 	if addMetaDag {
-		root, err = attachMetadataDag(db, root, fileSize)
+		root, err = db.AttachMetadataDag(root, fileSize)
 		if err != nil {
 			return nil, err
 		}
@@ -372,48 +371,3 @@ func fillNodeRec(db h.DagBuilderHelperInterface, node *h.FSNodeOverDag, depth in
 	return filledNode, nodeFileSize, nil
 }
 
-func attachMetadataDag(db *h.DagBuilderHelper, root ipld.Node, fileSize uint64) (ipld.Node, error) {
-	// Create a 'newRoot'.
-	newRoot := db.NewFSNodeOverDag(ft.TFile)
-
-	// Add metadata DAG as first child of 'newRoot'.
-	err := addMetadataChild(db, newRoot, db.GetMetaDb().GetMetaDagRoot())
-	if err != nil {
-		return nil, err
-	}
-
-	// Add the data DAG 'root' to 'newRoot'.
-	err = newRoot.AddChild(root, fileSize, db)
-	if err != nil {
-		return nil, err
-	}
-
-	// Commit 'newRoot' to make 'root'
-	root, err = newRoot.Commit()
-	if err != nil {
-		return nil, err
-	}
-
-	return root, nil
-}
-
-// Add the metadata DAG root 'mroot' as first child of 'newRoot'.
-func addMetadataChild(db *h.DagBuilderHelper, newRoot *h.FSNodeOverDag, mroot ipld.Node) error {
-	pnode, ok := mroot.(*dag.ProtoNode)
-	if !ok {
-		return h.ErrUnexpectedNodeType
-	}
-
-	fsn, err := ft.FSNodeFromBytes(pnode.Data())
-	if err != nil {
-		return err
-	}
-
-	metaFileSize := fsn.FileSize()
-	err = newRoot.AddChildDag(mroot, metaFileSize, db)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -370,4 +370,3 @@ func fillNodeRec(db h.DagBuilderHelperInterface, node *h.FSNodeOverDag, depth in
 
 	return filledNode, nodeFileSize, nil
 }
-

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -33,7 +33,7 @@ type DagBuilderHelperInterface interface {
 	Done() bool
 	Add(ipld.Node) error
 	NewLeafDataNode(pb.Data_DataType) (ipld.Node, uint64, error)
-    FillNodeLayer(*FSNodeOverDag, pb.Data_DataType) error
+	FillNodeLayer(*FSNodeOverDag, pb.Data_DataType) error
 	AttachMetadataDag(ipld.Node, uint64) (ipld.Node, error)
 }
 

--- a/importer/helpers/metadagbuilder.go
+++ b/importer/helpers/metadagbuilder.go
@@ -29,8 +29,12 @@ func (mdb *MetaDagBuilderHelper) NewLeafNode(data []byte, fsNodeType pb.Data_Dat
 	return mdb.db.NewLeafNode(data, fsNodeType)
 }
 
-func (mdb *MetaDagBuilderHelper) FillNodeLayer(node *FSNodeOverDag) error {
-	return mdb.db.FillNodeLayer(node)
+func (mdb *MetaDagBuilderHelper) FillNodeLayer(node *FSNodeOverDag, fsNodeType pb.Data_DataType) error {
+	return mdb.db.FillNodeLayer(node, fsNodeType)
+}
+
+func (mdb *MetaDagBuilderHelper) AttachMetadataDag(root ipld.Node, fileSize uint64) (ipld.Node, error) {
+	return mdb.db.AttachMetadataDag(root, fileSize)
 }
 
 // NewMetaLeafDataNode builds a metadata `node` with the meta data

--- a/importer/trickle/trickle_test.go
+++ b/importer/trickle/trickle_test.go
@@ -665,3 +665,190 @@ func TestAppendSingleBytesToEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func buildMetaTestDag(ds ipld.DAGService, maxLinks int, spl chunker.Splitter, metadata []byte, chunksize int64) (*merkledag.ProtoNode, error) {
+	dbp := h.DagBuilderParams{
+		Dagserv:   ds,
+		Maxlinks:  maxLinks,
+		TokenMetadata: metadata,
+		ChunkSize:     uint64(chunksize),
+	}
+
+	db, err := dbp.New(spl)
+	if err != nil {
+		return nil, err
+	}
+
+	err = BuildMetadataDag(db)
+	if err != nil {
+		return nil, err
+	}
+
+	mdb := db.GetMetaDb()
+	nd := mdb.GetMetaDagRoot()
+
+	pbnd, ok := nd.(*merkledag.ProtoNode)
+	if !ok {
+		return nil, merkledag.ErrNotProtobuf
+	}
+
+	//return pbnd, nil
+	return pbnd, VerifyTrickleDagStructure(pbnd, VerifyParams{
+		Getter:      ds,
+		Direct:      dbp.Maxlinks,
+		LayerRepeat: depthRepeat,
+		Metadata:    true,
+	})
+}
+
+func testMetaDataConsistency(t *testing.T, maxlinks int, mdata []byte, chunksize int64) {
+	read := bytes.NewReader(mdata)
+
+	ds := mdtest.Mock()
+	nd, err := buildMetaTestDag(ds, maxlinks, chunker.NewMetaSplitter(read, uint64(chunksize)), mdata, chunksize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := uio.NewDagReader(context.Background(), nd, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = arrComp(out, mdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMetaDataBasicConsistency(t *testing.T) {
+	b := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":250.5}`)
+	testMetaDataConsistency(t, h.DefaultLinksPerBlock, b, chunker.DefaultBlockSize)
+}
+
+func TestMetaDataTwoLevelDagConsistency(t *testing.T) {
+	b := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":12.4}`)
+	testMetaDataConsistency(t, 4, b, 32)
+}
+
+func TestMetaDataThreeLevelDagConsistency(t *testing.T) {
+	b := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":12.4}`)
+	testMetaDataConsistency(t, 4, b, 8)
+}
+
+func buildTestDagWithMetadata(ds ipld.DAGService, maxLinks int, dSpl chunker.Splitter, meta []byte, chunkSz int64) (*merkledag.ProtoNode, error) {
+	dbp := &h.DagBuilderParams{
+		Maxlinks:          maxLinks,
+		Dagserv:           ds,
+		TokenMetadata:     meta,
+		ChunkSize:         uint64(chunkSz),
+	}
+
+	db, err := dbp.New(dSpl)
+	if err != nil {
+		return nil, err
+	}
+
+	// Call the drivers to create meatadata and data trickle DAGs.
+	if db.IsThereMetaData() && !db.IsMetaDagBuilt() {
+		err := BuildMetadataDag(db)
+		if err != nil {
+			return nil, err
+		}
+		db.SetMetaDagBuilt(true)
+	}
+
+	nd, err := Layout(db)
+	if err != nil {
+		return nil, err
+	}
+
+	return nd.(*merkledag.ProtoNode), nil
+}
+
+func getTestDagWithMetadata(t *testing.T, ds ipld.DAGService, dsize int64, maxlinks int, meta []byte, chksize int64) (*merkledag.ProtoNode, []byte, []byte) {
+	data := make([]byte, dsize)
+	u.NewTimeSeededRand().Read(data)
+	dr := bytes.NewReader(data)
+
+	nd, err := buildTestDagWithMetadata(ds, maxlinks, chunker.NewSizeSplitter(dr, chksize), meta, chksize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return nd, data, meta
+}
+
+func getRootsForDataAndMetadata(t *testing.T, root ipld.Node, ds ipld.DAGService) (*merkledag.ProtoNode, *merkledag.ProtoNode, error) {
+	var nodes [2]ipld.Node
+
+	if len(root.Links()) < 2 {
+		return nil, nil, h.ErrUnexpectedProgramState
+	}
+
+	for i := 0; i < 2; i++ {
+		lnk := root.Links()[i]
+		c := lnk.Cid
+		child, err := ds.Get(context.Background(), c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nodes[i] = child
+	}
+	return nodes[0].(*merkledag.ProtoNode), nodes[1].(*merkledag.ProtoNode), nil
+}
+
+func testUserDataWithTokenMetadataRead(t *testing.T, dsize int64, maxlinks int, mdata []byte, chksize int64) {
+	ds := mdtest.Mock()
+	nd, should, mshould := getTestDagWithMetadata(t, ds, dsize, maxlinks, mdata, chksize)
+
+	mnd, dnd, err := getRootsForDataAndMetadata(t, nd, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mr, err := uio.NewDagReader(context.Background(), mnd, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := uio.NewDagReader(context.Background(), dnd, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mout, err := ioutil.ReadAll(mr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = arrComp(mout, mshould)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = arrComp(out, should)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBasicUserdataWithTokenMetadataRead(t *testing.T) {
+	b := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":12.4}`)
+	testUserDataWithTokenMetadataRead(t, 512, 2, b, 512)
+}
+
+func TestNoUserdataWithTokenMetadataRead(t *testing.T) {
+	b := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":12.4}`)
+	testUserDataWithTokenMetadataRead(t, 0, 2, b, 512)
+}

--- a/importer/trickle/trickle_test.go
+++ b/importer/trickle/trickle_test.go
@@ -668,8 +668,8 @@ func TestAppendSingleBytesToEmpty(t *testing.T) {
 
 func buildMetaTestDag(ds ipld.DAGService, maxLinks int, spl chunker.Splitter, metadata []byte, chunksize int64) (*merkledag.ProtoNode, error) {
 	dbp := h.DagBuilderParams{
-		Dagserv:   ds,
-		Maxlinks:  maxLinks,
+		Dagserv:       ds,
+		Maxlinks:      maxLinks,
 		TokenMetadata: metadata,
 		ChunkSize:     uint64(chunksize),
 	}
@@ -746,10 +746,10 @@ func TestMetaDataThreeLevelDagConsistency(t *testing.T) {
 
 func buildTestDagWithMetadata(ds ipld.DAGService, maxLinks int, dSpl chunker.Splitter, meta []byte, chunkSz int64) (*merkledag.ProtoNode, error) {
 	dbp := &h.DagBuilderParams{
-		Maxlinks:          maxLinks,
-		Dagserv:           ds,
-		TokenMetadata:     meta,
-		ChunkSize:         uint64(chunkSz),
+		Maxlinks:      maxLinks,
+		Dagserv:       ds,
+		TokenMetadata: meta,
+		ChunkSize:     uint64(chunkSz),
 	}
 
 	db, err := dbp.New(dSpl)

--- a/importer/trickle/trickledag.go
+++ b/importer/trickle/trickledag.go
@@ -77,11 +77,13 @@ func BuildMetadataDag(db *h.DagBuilderHelper) error {
 // fillTrickleRec creates a trickle (sub-)tree with an optional maximum specified depth
 // in the case maxDepth is greater than zero, or with unlimited depth otherwise
 // (where the DAG builder will signal the end of data to end the function).
-func fillTrickleRec(db h.DagBuilderHelperInterface, node *h.FSNodeOverDag, maxDepth int, fsType pb.Data_DataType ) (filledNode ipld.Node, nodeFileSize uint64, err error) {
+func fillTrickleRec(db h.DagBuilderHelperInterface, node *h.FSNodeOverDag, maxDepth int, fsType pb.Data_DataType) (filledNode ipld.Node, nodeFileSize uint64, err error) {
 	var nextFsType pb.Data_DataType
 	switch fsType {
-	case ft.TFile: nextFsType = ft.TRaw
-	case ft.TTokenMeta: nextFsType = ft.TTokenMeta
+	case ft.TFile:
+		nextFsType = ft.TRaw
+	case ft.TTokenMeta:
+		nextFsType = ft.TTokenMeta
 	default:
 		return nil, 0, h.ErrUnexpectedNodeType
 	}
@@ -90,7 +92,6 @@ func fillTrickleRec(db h.DagBuilderHelperInterface, node *h.FSNodeOverDag, maxDe
 	if err := db.FillNodeLayer(node, nextFsType); err != nil {
 		return nil, 0, err
 	}
-
 
 	// For each depth in [1, `maxDepth`) (or without limit if `maxDepth` is -1,
 	// initial call from `Layout`) add `depthRepeat` sub-graphs of that depth.

--- a/mod/dagmodifier_test.go
+++ b/mod/dagmodifier_test.go
@@ -17,7 +17,7 @@ import (
 	u "github.com/ipfs/go-ipfs-util"
 )
 
-func testModWrite(t *testing.T, beg, size uint64, orig []byte, dm *DagModifier, opts testu.NodeOpts) []byte {
+func testModWrite(t *testing.T, beg, size uint64, orig []byte, dm *DagModifier, opts testu.NodeOpts, meta bool) []byte {
 	newdata := make([]byte, size)
 	r := u.NewTimeSeededRand()
 	r.Read(newdata)
@@ -36,12 +36,12 @@ func testModWrite(t *testing.T, beg, size uint64, orig []byte, dm *DagModifier, 
 		t.Fatalf("Mod length not correct! %d != %d", nmod, size)
 	}
 
-	verifyNode(t, orig, dm, opts)
+	verifyNode(t, orig, dm, opts, meta)
 
 	return orig
 }
 
-func verifyNode(t *testing.T, orig []byte, dm *DagModifier, opts testu.NodeOpts) {
+func verifyNode(t *testing.T, orig []byte, dm *DagModifier, opts testu.NodeOpts, meta bool) {
 	nd, err := dm.GetNode()
 	if err != nil {
 		t.Fatal(err)
@@ -53,6 +53,7 @@ func verifyNode(t *testing.T, orig []byte, dm *DagModifier, opts testu.NodeOpts)
 		LayerRepeat: 4,
 		Prefix:      &opts.Prefix,
 		RawLeaves:   opts.RawLeavesUsed,
+		Metadata:   meta,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -103,26 +104,26 @@ func testDagModifierBasic(t *testing.T, opts testu.NodeOpts) {
 	length := uint64(60)
 
 	t.Log("Testing mod within zero block")
-	b = testModWrite(t, beg, length, b, dagmod, opts)
+	b = testModWrite(t, beg, length, b, dagmod, opts, false)
 
 	// Within bounds of existing file
 	beg = 1000
 	length = 4000
 	t.Log("Testing mod within bounds of existing multiblock file.")
-	b = testModWrite(t, beg, length, b, dagmod, opts)
+	b = testModWrite(t, beg, length, b, dagmod, opts, false)
 
 	// Extend bounds
 	beg = 49500
 	length = 4000
 
 	t.Log("Testing mod that extends file.")
-	b = testModWrite(t, beg, length, b, dagmod, opts)
+	b = testModWrite(t, beg, length, b, dagmod, opts, false)
 
 	// "Append"
 	beg = uint64(len(b))
 	length = 3000
 	t.Log("Testing pure append")
-	_ = testModWrite(t, beg, length, b, dagmod, opts)
+	_ = testModWrite(t, beg, length, b, dagmod, opts, false)
 
 	// Verify reported length
 	node, err := dagmod.GetNode()
@@ -181,7 +182,7 @@ func testMultiWrite(t *testing.T, opts testu.NodeOpts) {
 		}
 	}
 
-	verifyNode(t, data, dagmod, opts)
+	verifyNode(t, data, dagmod, opts, false)
 }
 
 func TestMultiWriteAndFlush(t *testing.T) {
@@ -219,7 +220,7 @@ func testMultiWriteAndFlush(t *testing.T, opts testu.NodeOpts) {
 		}
 	}
 
-	verifyNode(t, data, dagmod, opts)
+	verifyNode(t, data, dagmod, opts, false)
 }
 
 func TestWriteNewFile(t *testing.T) {
@@ -251,7 +252,7 @@ func testWriteNewFile(t *testing.T, opts testu.NodeOpts) {
 		t.Fatal("Wrote wrong amount")
 	}
 
-	verifyNode(t, towrite, dagmod, opts)
+	verifyNode(t, towrite, dagmod, opts, false)
 }
 
 func TestMultiWriteCoal(t *testing.T) {
@@ -287,7 +288,7 @@ func testMultiWriteCoal(t *testing.T, opts testu.NodeOpts) {
 
 	}
 
-	verifyNode(t, data, dagmod, opts)
+	verifyNode(t, data, dagmod, opts, false)
 }
 
 func TestLargeWriteChunks(t *testing.T) {
@@ -857,4 +858,94 @@ func getOffset(reader uio.DagReader) int64 {
 		panic("failed to retrieve offset: " + err.Error())
 	}
 	return offset
+}
+
+func TestTrickleMetaDagAppend(t *testing.T) {
+	t.Run("opts=ProtoBufLeaves", func(t *testing.T) { testTrickleMetaDagAppendBasic(t, testu.UseProtoBufLeaves) })
+}
+
+func testTrickleMetaDagAppendBasic(t *testing.T, opts testu.NodeOpts) {
+	inputMdata := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":12.4}`)
+	dserv := testu.GetDAGServ()
+
+	_, node := testu.GetRandomNode(t, dserv, 64,
+		testu.UseTrickleWithMetadata(inputMdata, 32))
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	mnode, err := unixfs.GetMetaSubdagRoot(ctx, node, dserv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dagmod, err := NewDagModifier(ctx, mnode, dserv, testu.MetaSplitterGen((32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "Append"
+	beg := uint64(len(inputMdata))
+	length := uint64(3000)
+	_ = testModWrite(t, beg, length, inputMdata, dagmod, opts, true)
+
+	// Verify reported length
+	node, err = dagmod.GetNode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := fileSize(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := uint64(beg + 3000)
+	if size != expected {
+		t.Fatalf("Final reported size is incorrect [%d != %d]", size, expected)
+	}
+}
+
+func TestBalancedMetaDagAppend(t *testing.T) {
+	t.Run("opts=ProtoBufLeaves", func(t *testing.T) { testBalancedMetaDagAppendBasic(t, testu.UseProtoBufLeaves) })
+}
+
+func testBalancedMetaDagAppendBasic(t *testing.T, opts testu.NodeOpts) {
+	inputMdata := []byte(`{"nodeid":"QmURnhjU6b2Si4rqwfpD4FDGTzJH3hGRAWSQmXtagywwdz","Price":12.4}`)
+	dserv := testu.GetDAGServ()
+
+	_, node := testu.GetRandomNode(t, dserv, 64,
+		testu.UseBalancedWithMetadata(inputMdata, 32))
+	ctx, closer := context.WithCancel(context.Background())
+	defer closer()
+
+	mnode, err := unixfs.GetMetaSubdagRoot(ctx, node, dserv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dagmod, err := NewDagModifier(ctx, mnode, dserv, testu.MetaSplitterGen((32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "Append"
+	beg := uint64(len(inputMdata))
+	length := uint64(3000)
+	_ = testModWrite(t, beg, length, inputMdata, dagmod, opts, true)
+
+	// Verify reported length
+	node, err = dagmod.GetNode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := fileSize(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := uint64(beg + 3000)
+	if size != expected {
+		t.Fatalf("Final reported size is incorrect [%d != %d]", size, expected)
+	}
 }

--- a/mod/dagmodifier_test.go
+++ b/mod/dagmodifier_test.go
@@ -53,7 +53,7 @@ func verifyNode(t *testing.T, orig []byte, dm *DagModifier, opts testu.NodeOpts,
 		LayerRepeat: 4,
 		Prefix:      &opts.Prefix,
 		RawLeaves:   opts.RawLeavesUsed,
-		Metadata:   meta,
+		Metadata:    meta,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/test/utils.go
+++ b/test/utils.go
@@ -29,6 +29,12 @@ func SizeSplitterGen(size int64) chunker.SplitterGen {
 	}
 }
 
+func MetaSplitterGen(size int64) chunker.SplitterGen {
+	return func(r io.Reader) chunker.Splitter {
+		return chunker.NewMetaSplitter(r, uint64(size))
+	}
+}
+
 // GetDAGServ returns a mock DAGService.
 func GetDAGServ() ipld.DAGService {
 	return mdagmock.Mock()
@@ -61,6 +67,10 @@ var (
 
 func UseBalancedWithMetadata(mdata []byte, chkSize uint64) NodeOpts {
 	return NodeOpts{Prefix: mdag.V0CidPrefix(), Balanced: true, metadata: mdata, chunkSize: chkSize}
+}
+
+func UseTrickleWithMetadata(mdata []byte, chkSize uint64) NodeOpts {
+	return NodeOpts{Prefix: mdag.V0CidPrefix(), metadata: mdata, chunkSize: chkSize}
 }
 
 func UseReedSolomon(numData, numParity uint64, mdata []byte, chkSize uint64) NodeOpts {
@@ -119,14 +129,18 @@ func GetNode(t testing.TB, dserv ipld.DAGService, data []byte, opts NodeOpts) ip
 		t.Fatal(err)
 	}
 	var node ipld.Node
-	if opts.Balanced {
-		if db.IsThereMetaData() && !db.IsMetaDagBuilt() {
-			err := balanced.BuildMetadataDag(db)
-			if err != nil {
-				t.Fatal(err)
-			}
-			db.SetMetaDagBuilt(true)
+	if db.IsThereMetaData() && !db.IsMetaDagBuilt() {
+		if opts.Balanced {
+			err = balanced.BuildMetadataDag(db)
+		} else {
+			err = trickle.BuildMetadataDag(db)
 		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		db.SetMetaDagBuilt(true)
+	}
+	if opts.Balanced {
 		node, err = balanced.Layout(db)
 	} else {
 		node, err = trickle.Layout(db)


### PR DESCRIPTION
1. Added UnixFS metadata support for trickle format.
2. Added unit tests in trickle_test.go
3. Passed all the unit tests in UnixFS.