### PR TITLE
Change return type of GetChildrenForDagWithMeta to a struct containing

### DIFF
--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -263,7 +263,7 @@ func checkAndSplitMetadata(ctx context.Context, nd ipld.Node, ds ipld.DAGService
 		if children == nil {
 			return nd, nil, nil
 		}
-		return children[1], children[0], nil
+		return children.DataNode, children.MetaNode, nil
 	}
 
 	return nd, nil, nil


### PR DESCRIPTION
MetaNode and DataNode to make it clear (instead of 2-slice).

Unit tests pass.