### PR TITLE
BTFS-965: Append metadata items to existing metadata

### DIFF
--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -2,6 +2,8 @@ package unixfile
 
 import (
 	"context"
+	"github.com/TRON-US/go-unixfs/importer/helpers"
+
 	//"fmt"
 	"io/ioutil"
 	"testing"
@@ -45,7 +47,7 @@ func TestUnixFsFileReadWithMetadata(t *testing.T) {
 	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}`)
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
-		testu.UseBalancedWithMetadata(inputMeta, 512))
+		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMeta, 512))
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
+	golang.org/x/net v0.0.0-20190611141213-3f473d35a33a
 )
 
 go 1.13

--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -50,6 +50,7 @@
 package balanced
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	ft "github.com/TRON-US/go-unixfs"
@@ -58,7 +59,6 @@ import (
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
-	"golang.org/x/net/context"
 )
 
 // Layout builds a balanced DAG layout. In a balanced DAG of depth 1, leaf nodes
@@ -555,6 +555,7 @@ func Append(ctx context.Context, baseiNode ipld.Node, db *h.DagBuilderHelper) (o
 // VerifyParams is used by VerifyBalancedDagStructure
 type VerifyParamsForBalanced struct {
 	Getter    ipld.NodeGetter
+	Ctx       context.Context
 	MaxLinks  int
 	TreeDepth int
 	Prefix    *cid.Prefix
@@ -647,7 +648,7 @@ func verifyBalancedDagRec(n ipld.Node, p VerifyParamsForBalanced) error {
 	}
 
 	for i := 0; i < len(nd.Links()); i++ {
-		child, err := nd.Links()[i].GetNode(context.TODO(), p.Getter)
+		child, err := nd.Links()[i].GetNode(p.Ctx, p.Getter)
 		if err != nil {
 			return err
 		}

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -24,6 +24,7 @@ var (
 	ErrUnknownNodeType        = errors.New("unknown node type")
 	ErrUnexpectedNodeType     = errors.New("unexpected node type")
 	ErrUnexpectedProgramState = errors.New("unexpected program state occurred")
+	ErrUnexpectedNilArgument  = errors.New("unexpected nil argument value")
 )
 
 type DagBuilderHelperInterface interface {
@@ -103,6 +104,9 @@ type DagBuilderParams struct {
 
 	// MetadataProcessed indicates whether token metadata is processed or not.
 	MetadataProcessed bool
+
+	// TrickleFormat indicates the client requested trickle tree format
+	TrickleFormat bool
 }
 
 // New generates a new DagBuilderHelper from the given params and a given
@@ -551,4 +555,17 @@ func (n *FSNodeOverDag) GetChild(ctx context.Context, i int, ds ipld.DAGService)
 	}
 
 	return NewFSNFromDag(pbn)
+}
+
+// fileTYpe returns the data type of the `ft.FSNode`.
+func (n *FSNodeOverDag) GetFileNodeType() pb.Data_DataType {
+	return n.file.Type()
+}
+
+func (n *FSNodeOverDag) ValidTrickleInnerNodeType() (pb.Data_DataType, error) {
+	fsType := n.GetFileNodeType()
+	if fsType != ft.TFile && fsType != ft.TTokenMeta {
+		return 0, ErrUnexpectedNodeType
+	}
+	return fsType, nil
 }

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -557,7 +557,7 @@ func (n *FSNodeOverDag) GetChild(ctx context.Context, i int, ds ipld.DAGService)
 	return NewFSNFromDag(pbn)
 }
 
-// fileTYpe returns the data type of the `ft.FSNode`.
+// GetFileNodeType returns the data type of the `ft.FSNode`.
 func (n *FSNodeOverDag) GetFileNodeType() pb.Data_DataType {
 	return n.file.Type()
 }

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -26,5 +26,7 @@ var roughLinkSize = 34 + 8 + 5   // sha256 multihash + size + no name + protobuf
 //                            = (approximately) 174
 var DefaultLinksPerBlock = roughLinkBlockSize / roughLinkSize
 
+//var DefaultLinksPerBlock = 2
+
 // ErrSizeLimitExceeded signals that a block is larger than BlockSizeLimit.
 var ErrSizeLimitExceeded = fmt.Errorf("object size limit exceeded")

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -26,7 +26,5 @@ var roughLinkSize = 34 + 8 + 5   // sha256 multihash + size + no name + protobuf
 //                            = (approximately) 174
 var DefaultLinksPerBlock = roughLinkBlockSize / roughLinkSize
 
-//var DefaultLinksPerBlock = 2
-
 // ErrSizeLimitExceeded signals that a block is larger than BlockSizeLimit.
 var ErrSizeLimitExceeded = fmt.Errorf("object size limit exceeded")

--- a/importer/helpers/metadagbuilder.go
+++ b/importer/helpers/metadagbuilder.go
@@ -7,6 +7,12 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
+type SuperMeta struct {
+	ChunkSize     uint64
+	MaxLinks      uint64
+	TrickleFormat bool
+}
+
 type MetaDagBuilderHelper struct {
 	db          DagBuilderHelper
 	metaSpl     chunker.Splitter

--- a/importer/helpers/metadagbuilder.go
+++ b/importer/helpers/metadagbuilder.go
@@ -7,6 +7,8 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
+// SuperMeta contains the common metadata fields for a BTFS object
+// to be used for metadata readers and modifiers
 type SuperMeta struct {
 	ChunkSize     uint64
 	MaxLinks      uint64

--- a/io/dagreader_test.go
+++ b/io/dagreader_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"github.com/TRON-US/go-unixfs/importer/helpers"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -244,7 +245,7 @@ func TestMetadataRead(t *testing.T) {
 	dserv := testu.GetDAGServ()
 
 	inbuf, node := testu.GetRandomNode(t, dserv, 500,
-		testu.UseBalancedWithMetadata(inputMdata, 512))
+		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMdata, 512))
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 

--- a/mod/dagmodifier.go
+++ b/mod/dagmodifier.go
@@ -6,10 +6,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/TRON-US/go-unixfs/importer/balanced"
 	"io"
 
 	ft "github.com/TRON-US/go-unixfs"
+	"github.com/TRON-US/go-unixfs/importer/balanced"
 	help "github.com/TRON-US/go-unixfs/importer/helpers"
 	trickle "github.com/TRON-US/go-unixfs/importer/trickle"
 	uio "github.com/TRON-US/go-unixfs/io"
@@ -171,7 +171,7 @@ func (dm *DagModifier) Write(b []byte) (int, error) {
 
 // Size returns the Filesize of the node
 func (dm *DagModifier) Size() (int64, error) {
-	fileSize, err := fileSize(dm.curNode)
+	fileSize, err := FileSize(dm.curNode)
 	if err != nil {
 		return 0, err
 	}
@@ -181,7 +181,7 @@ func (dm *DagModifier) Size() (int64, error) {
 	return int64(fileSize), nil
 }
 
-func fileSize(n ipld.Node) (uint64, error) {
+func FileSize(n ipld.Node) (uint64, error) {
 	switch nd := n.(type) {
 	case *mdag.ProtoNode:
 		fsn, err := ft.FSNodeFromBytes(nd.Data())
@@ -212,7 +212,7 @@ func (dm *DagModifier) Sync() error {
 	// Number of bytes we're going to write
 	buflen := dm.wrBuf.Len()
 
-	fs, err := fileSize(dm.curNode)
+	fs, err := FileSize(dm.curNode)
 	if err != nil {
 		return err
 	}
@@ -571,7 +571,7 @@ func (dm *DagModifier) dagTruncate(ctx context.Context, n ipld.Node, size uint64
 			return nil, err
 		}
 
-		childsize, err := fileSize(child)
+		childsize, err := FileSize(child)
 		if err != nil {
 			return nil, err
 		}

--- a/mod/dagmodifier_test.go
+++ b/mod/dagmodifier_test.go
@@ -3,8 +3,6 @@ package mod
 import (
 	"context"
 	"fmt"
-	"github.com/TRON-US/go-unixfs/importer/balanced"
-	"github.com/TRON-US/go-unixfs/importer/helpers"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -15,6 +13,8 @@ import (
 	dag "github.com/ipfs/go-merkledag"
 
 	"github.com/TRON-US/go-unixfs"
+	"github.com/TRON-US/go-unixfs/importer/balanced"
+	"github.com/TRON-US/go-unixfs/importer/helpers"
 	u "github.com/ipfs/go-ipfs-util"
 )
 
@@ -69,6 +69,7 @@ func verifyNode(t *testing.T, orig []byte, dm *DagModifier, opts testu.NodeOpts,
 		}
 		err = balanced.VerifyBalancedDagStructure(nd, balanced.VerifyParamsForBalanced{
 			Getter:    dm.dagserv,
+			Ctx:       dm.ctx,
 			MaxLinks:  maxLinks,
 			TreeDepth: treeDepth,
 			Prefix:    &opts.Prefix,
@@ -161,7 +162,7 @@ func testDagModifierBasic(t *testing.T, opts testu.NodeOpts) {
 		t.Fatal(err)
 	}
 
-	size, err := fileSize(node)
+	size, err := FileSize(node)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -929,7 +930,7 @@ func testTrickleMetaDagAppend(t *testing.T, opts testu.NodeOpts, dataSize uint64
 		t.Fatal(err)
 	}
 
-	size, err := fileSize(node)
+	size, err := FileSize(node)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +984,7 @@ func testBalancedMetaDagAppendBasic(t *testing.T, opts testu.NodeOpts, dataSize 
 		t.Fatal(err)
 	}
 
-	size, err := fileSize(node)
+	size, err := FileSize(node)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
1. Modified trickle dagmodifier to process token metadata. 
2. Add unit tests in dagmodifier_test.go for `Append` operation for metadata for trickle format DAG.
3. Modified dagmodifier to add functionality to `Append` token metadata for balanced format DAG.
4. Add unit tests in dagmodifier_test.go for `Append` operation for metadata for balanced format DAG.
5. Minor changes in unixfile.go for `btfs cat` command.