### PR TITLE
BTFS-969: implement deleting/updating metadata along with BTFS-1006

### DIFF
--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -180,7 +180,7 @@ func NewUnixfsFile(ctx context.Context, dserv ipld.DAGService, nd ipld.Node, met
 	// Keep 'nd' if raw node
 	if !rawNode {
 		// Split metadata node and data node if available
-		dataNode, metaNode, err := checkAndSplitMetadata(ctx, nd, dserv, meta)
+		dataNode, metaNode, err := CheckAndSplitMetadata(ctx, nd, dserv, meta)
 		if err != nil {
 			return nil, err
 		}
@@ -242,7 +242,7 @@ func NewUnixfsFile(ctx context.Context, dserv ipld.DAGService, nd ipld.Node, met
 //    return the second child node that is the root of user data sub-DAG.
 // Case #2: if 'nd' is metadata and the given `meta` is true, return nd. Otherwise return error.
 // Case #3: if 'nd' is user data, return 'nd'.
-func checkAndSplitMetadata(ctx context.Context, nd ipld.Node, ds ipld.DAGService, meta bool) (ipld.Node, ipld.Node, error) {
+func CheckAndSplitMetadata(ctx context.Context, nd ipld.Node, ds ipld.DAGService, meta bool) (ipld.Node, ipld.Node, error) {
 	n := nd.(*dag.ProtoNode)
 
 	fsType, err := ft.GetFSType(n)

--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -47,7 +47,7 @@ func TestUnixFsFileReadWithMetadata(t *testing.T) {
 	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}`)
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
-		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMeta, 512))
+		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMeta, 512, nil))
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
+	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f
 	golang.org/x/net v0.0.0-20190611141213-3f473d35a33a
 )
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spaolacci/murmur3 v1.1.0
-	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
+	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830
 	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f
 	golang.org/x/net v0.0.0-20190611141213-3f473d35a33a
 )

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,6 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830
-	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f
-	golang.org/x/net v0.0.0-20190611141213-3f473d35a33a
 )
 
 go 1.13

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -35,7 +35,7 @@ type DagBuilderHelperInterface interface {
 	Add(ipld.Node) error
 	NewLeafDataNode(pb.Data_DataType) (ipld.Node, uint64, error)
 	FillNodeLayer(*FSNodeOverDag, pb.Data_DataType) error
-	AttachMetadataDag(ipld.Node, uint64) (ipld.Node, error)
+	AttachMetadataDag(ipld.Node, uint64, ipld.Node) (ipld.Node, error)
 }
 
 // dagBuilderHelper contains the shared fields among various different helpers
@@ -408,12 +408,12 @@ func (db *DagBuilderHelper) NewFSNFromDag(nd *dag.ProtoNode) (*FSNodeOverDag, er
 	return NewFSNFromDag(nd)
 }
 
-func (db *DagBuilderHelper) AttachMetadataDag(root ipld.Node, fileSize uint64) (ipld.Node, error) {
+func (db *DagBuilderHelper) AttachMetadataDag(root ipld.Node, fileSize uint64, metaRoot ipld.Node) (ipld.Node, error) {
 	// Create a 'newRoot'.
 	newRoot := db.NewFSNodeOverDag(ft.TFile)
 
 	// Add metadata DAG as first child of 'newRoot'.
-	err := db.addMetadataChild(newRoot, db.GetMetaDb().GetMetaDagRoot())
+	err := db.addMetadataChild(newRoot, metaRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/importer/helpers/metadagbuilder.go
+++ b/importer/helpers/metadagbuilder.go
@@ -21,6 +21,22 @@ type MetaDagBuilderHelper struct {
 	metaDagRoot ipld.Node // Metadata Dag root node
 }
 
+func NewMetaDagBuilderHelper(idb DagBuilderHelper, spl chunker.Splitter, mroot ipld.Node) *MetaDagBuilderHelper {
+	return &MetaDagBuilderHelper{
+		db:          idb,
+		metaSpl:     spl,
+		metaDagRoot: mroot,
+	}
+}
+
+func GetSuperMeta(chunkSize uint64, maxLinks uint64, trickleFormat bool) interface{} {
+	return &SuperMeta{
+		ChunkSize:     chunkSize,
+		MaxLinks:      maxLinks,
+		TrickleFormat: trickleFormat,
+	}
+}
+
 func (mdb *MetaDagBuilderHelper) SetSpl() {
 	mdb.db.spl = mdb.metaSpl
 }
@@ -41,8 +57,8 @@ func (mdb *MetaDagBuilderHelper) FillNodeLayer(node *FSNodeOverDag, fsNodeType p
 	return mdb.db.FillNodeLayer(node, fsNodeType)
 }
 
-func (mdb *MetaDagBuilderHelper) AttachMetadataDag(root ipld.Node, fileSize uint64) (ipld.Node, error) {
-	return mdb.db.AttachMetadataDag(root, fileSize)
+func (mdb *MetaDagBuilderHelper) AttachMetadataDag(root ipld.Node, fileSize uint64, mRoot ipld.Node) (ipld.Node, error) {
+	return mdb.db.AttachMetadataDag(root, fileSize, mRoot)
 }
 
 // NewMetaLeafDataNode builds a metadata `node` with the meta data

--- a/importer/helpers/metadagbuilder.go
+++ b/importer/helpers/metadagbuilder.go
@@ -29,7 +29,7 @@ func NewMetaDagBuilderHelper(idb DagBuilderHelper, spl chunker.Splitter, mroot i
 	}
 }
 
-func GetSuperMeta(chunkSize uint64, maxLinks uint64, trickleFormat bool) interface{} {
+func GetSuperMeta(chunkSize uint64, maxLinks uint64, trickleFormat bool) *SuperMeta {
 	return &SuperMeta{
 		ChunkSize:     chunkSize,
 		MaxLinks:      maxLinks,

--- a/io/dagreader_test.go
+++ b/io/dagreader_test.go
@@ -245,7 +245,7 @@ func TestMetadataRead(t *testing.T) {
 	dserv := testu.GetDAGServ()
 
 	inbuf, node := testu.GetRandomNode(t, dserv, 500,
-		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMdata, 512))
+		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMdata, 512, nil))
 	ctx, closer := context.WithCancel(context.Background())
 	defer closer()
 

--- a/mod/dagmodifier.go
+++ b/mod/dagmodifier.go
@@ -705,7 +705,10 @@ func (mdm *MetaDagModifier) AddMetadata(root ipld.Node, metadata []byte) (ipld.N
 		// Scenario #2: Update case.
 		if exists {
 			// Truncate(0) on the metadata sub-DAG.
-			mdm.Truncate(0)
+			err := mdm.Truncate(0)
+			if err != nil {
+			    return nil, err
+			}
 
 			// iterate the inputM to put its (k, v) pairs to existing map.
 			for k, v := range inputM {

--- a/mod/dagmodifier_test.go
+++ b/mod/dagmodifier_test.go
@@ -963,7 +963,8 @@ func TestBalancedMetaDagAppend(t *testing.T) {
 
 	t.Run("opts=UseBalancedWithDepthZeroMetadata-32-staticData", func(t *testing.T) {
 		cid := "QmaLy2PZK3PyiLjYLo7QPW4UDVT3igSEXUhwG6HN4tX2Ae"
-		testBalancedMetadataAppendWithUserData(t, testu.UseBalancedWithMetadata(2, inMdataDepthZero, 32, mDataToModify), userData, cid)
+		//testBalancedMetadataAppendWithUserData(t, testu.UseBalancedWithMetadata(2, inMdataDepthZero, 32, mDataToModify), userData, cid)
+		testBalancedMetadataAppendWithUserData(t, testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inMdataDepthZero, 256*1024, mDataToModify), userData, cid)
 	})
 	t.Run("opts=UseBalancedWithDepthZeroMetadata-32", func(t *testing.T) {
 		testBalancedMetadataAppend(t, testu.UseBalancedWithMetadata(2, inMdataDepthZero, 32, mDataToModify), 72, "")
@@ -1009,6 +1010,7 @@ func testBalancedMetaDagAppend(t *testing.T, opts testu.NodeOpts, userDataSize i
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	dagmod, err := NewDagModifierBalanced(ctx, mnode, dserv, testu.MetaSplitterGen((int64(opts.ChunkSize))), opts.MaxLinks)
 	if err != nil {
 		t.Fatal(err)

--- a/util/utils.go
+++ b/util/utils.go
@@ -1,0 +1,41 @@
+package util
+
+// Intersects returns true if the given two maps intersect.
+func Intersects(m map[string]interface{}, inputM map[string]interface{}) bool {
+	for k, _ := range inputM {
+		_, isPresent := m[k]
+		if isPresent {
+			return true
+		}
+	}
+	return false
+}
+
+// KeyIntersects returns true if the key set of the given `m`
+// and the string array `inputKeys` intersects.
+func KeyIntersects(m map[string]interface{}, inputKeys []string) bool {
+	for _, k := range inputKeys {
+		_, isPresent := m[k]
+		if isPresent {
+			return true
+		}
+	}
+	return false
+}
+
+// EqualKeySets returns true if the key set of the given `m` equals
+// the given key string array `inputKeys`.
+func EqualKeySets(m map[string]interface{}, inputKeys []string) bool {
+	if len(m) != len(inputKeys) {
+		return false
+	}
+
+	for _, ik := range inputKeys {
+		_, isPresent := m[ik]
+		if !isPresent {
+			return false
+		}
+	}
+
+	return true
+}

--- a/util/utils_test.go
+++ b/util/utils_test.go
@@ -1,0 +1,106 @@
+package util
+
+import (
+	"github.com/warpfork/go-wish/cmp"
+	"testing"
+)
+
+func testMapIntersects(t *testing.T) {
+	intersectTestTable := map[string]struct {
+		input1 		map[string]interface{}
+		input2 		map[string]interface{}
+		want  		bool
+	}{
+		"partial":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: map[string]interface{}{"key1": 3},
+			want: true, },
+		"equal":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: map[string]interface{}{"key1": 123, "key2": "val2"},
+			want: true},
+		"empty":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: map[string]interface{}{"key3": 123, "key4": "val2"},
+			want: false},
+	}
+
+	for name, td := range intersectTestTable {
+		t.Run(name, func(t *testing.T) {
+			got := Intersects(td.input1, td.input2)
+			diff := cmp.Diff(td.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+func testKeyIntersects(t *testing.T) {
+	keyIntersectTestTable := map[string]struct {
+		input1 		map[string]interface{}
+		input2 		map[string]interface{}
+		want  		bool
+	}{
+		"partial":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: map[string]interface{}{"key1": 3},
+			want: true, },
+		"equal":
+		{input1: map[string]interface{}{"key1": "", "key2": "val2"},
+			input2: map[string]interface{}{"key1": 123, "key2": "val2"},
+			want: true},
+		"empty":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: map[string]interface{}{"key3": 123, "key4": "val2"},
+			want: false},
+	}
+
+	for name, td := range keyIntersectTestTable {
+		t.Run(name, func(t *testing.T) {
+			got := Intersects(td.input1, td.input2)
+			diff := cmp.Diff(td.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+func testEqualKeySets(t *testing.T) {
+	equalKeySetTestTable := map[string]struct {
+		input1 		map[string]interface{}
+		input2 		[]string
+		want  		bool
+	}{
+		"partial":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: []string{"key1"},
+			want: false, },
+		"equal":
+		{input1: map[string]interface{}{"key1": "", "key2": "val2"},
+			input2: []string{"key1", "key2"},
+			want: true},
+		"empty":
+		{input1: map[string]interface{}{"key1": 123, "key2": "val2"},
+			input2: []string{"key3", "key4"},
+			want: false},
+	}
+
+	for name, td := range equalKeySetTestTable {
+		t.Run(name, func(t *testing.T) {
+			got := EqualKeySets(td.input1, td.input2)
+			diff := cmp.Diff(td.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+
+func TestIntersects(t *testing.T) {
+	testMapIntersects(t)
+	testKeyIntersects(t)
+	testEqualKeySets(t)
+}


### PR DESCRIPTION
This PR is for adding the functionalities to add(adding metadata to a file without preexisting metadata)/update/delete token metadata. 
1. Added new unit tests for appending metadata to dagmodifier_test.go
2. Modified dagmodifier.go to add AddMetadata()/RemoveMetadata() as major logic methods 
   to perform the functionalities. 
3. Modified importer/balanced related methods to support the new functionalities.
4. Modified importer/trickle related methods to support the new functionalities.
5. Misc: minor changes to support the new functionalities.