### PR TITLE
BTFS-1191: Reed Solomon based operations on directory object in one r…

### DIFF
--- a/file/reed_solomon_file.go
+++ b/file/reed_solomon_file.go
@@ -1,0 +1,466 @@
+package unixfile
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/TRON-US/go-unixfs/importer/balanced"
+	ihelper "github.com/TRON-US/go-unixfs/importer/helpers"
+	"github.com/TRON-US/go-unixfs/importer/trickle"
+	"github.com/TRON-US/go-unixfs/util"
+	"io"
+	"sync"
+
+	uio "github.com/TRON-US/go-unixfs/io"
+
+	chunker "github.com/TRON-US/go-btfs-chunker"
+	files "github.com/TRON-US/go-btfs-files"
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+// TODO: 12/11 possibly create a pool DP if not possible to have a session..
+// But use api.core().getSession(ctx)?
+
+const (
+	ReedSolomonDagOff   = 0
+	ReedSolomonDagOpen  = 1
+	ReedSolomonDagNext  = 2
+	ReedSolomonDagClose = 3
+)
+
+type ReedSolomonDag struct {
+	state     int
+	buff      *bytes.Buffer
+	offset    uint64
+	curFile   *uio.FileNode
+	lock      sync.RWMutex
+	cidString string
+}
+
+type rsDirectory struct {
+	ctx       context.Context
+	dserv     ipld.DAGService
+	dir       uio.ReedSolomonDirectory
+	size      int64
+	cidString string
+}
+
+func (d *rsDirectory) Close() error {
+	return nil
+}
+
+func (d *rsDirectory) Entries() files.DirIterator {
+
+	fileCh := make(chan interface{}, prefetchFiles)
+	errCh := make(chan error, 1)
+	// Invoke goroutine to provide links of the current receiver `d`
+	// via `fileCh`.
+	go func() {
+		errCh <- d.dir.ForEachLink(d.ctx, func(link interface{}) error {
+			if d.ctx.Err() != nil {
+				return d.ctx.Err()
+			}
+			select {
+			case fileCh <- link:
+			case <-d.ctx.Done():
+				return d.ctx.Err()
+			}
+			return nil
+		})
+
+		// close channels indicating sender side is done.
+		close(errCh)
+		close(fileCh)
+	}()
+
+	return &rsIterator{
+		ctx:       d.ctx,
+		cidString: d.cidString,
+		files:     fileCh,
+		rsDir:     d,
+		errCh:     errCh,
+		dserv:     d.dserv,
+	}
+}
+
+func (d *rsDirectory) Size() (int64, error) {
+	return d.size, nil
+}
+
+type rsIterator struct {
+	state     int
+	ctx       context.Context
+	cidString string
+	files     chan interface{}
+	dserv     ipld.DAGService
+	rsDir     *rsDirectory
+
+	curName string
+	curFile files.Node
+
+	err   error
+	errCh chan error
+}
+
+func (it *rsIterator) Name() string {
+	return it.curName
+}
+
+func (it *rsIterator) Node() files.Node {
+	return it.curFile
+}
+
+func (it *rsIterator) Next() bool {
+	if it.err != nil {
+		return false
+	}
+
+	var l interface{}
+	var ok bool
+	// Loop until getting `l` without an error.
+	for !ok { // while ok == false
+		if it.files == nil && it.errCh == nil {
+			return false
+		}
+		select {
+		case l, ok = <-it.files:
+			if !ok {
+				it.files = nil
+			}
+		case err := <-it.errCh:
+			it.errCh = nil
+			it.err = err
+
+			if err != nil {
+				return false
+			}
+		}
+	}
+
+	it.curFile = nil
+
+	node, err := GetRsNode(l)
+	if err != nil {
+		it.err = err
+		return false
+	}
+
+	it.curName = node.Name()
+	if it.curName == uio.SmallestString {
+		return it.err == nil
+	}
+
+	switch nd := node.(type) {
+	case *uio.DirNode:
+		it.curFile, it.err = NewReedSolomonSubDirectory(it.ctx, it.dserv, it.cidString, nd)
+	case *uio.FileNode:
+		it.curFile, it.err = NewReedSolomonFileUnderDirectory(it.ctx, it.dserv, it.cidString, nd)
+	case *uio.SymlinkNode:
+		it.curFile, it.err = files.NewLinkFile(nd.Data, nil), nil
+	default:
+		it.err = errors.New("unexpected Node at Next(), possibly program error")
+		return false
+	}
+
+	return it.err == nil
+}
+
+func GetRsNode(l interface{}) (uio.Node, error) {
+	m, ok := l.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected Node format. Probably program error.")
+	}
+	mm, ok := m["BaseNode"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected Node format. Possibly program error.")
+	}
+
+	var base uio.BaseNode
+	typ, ok := mm["NodeType"].(float64)
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected NodeType format")
+	}
+	base.NodeType = int(typ)
+	p, ok := mm["NodePath"].(string)
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected NodePath format")
+	}
+	base.NodePath = p
+	n, ok := mm["NodeName"].(string)
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected NodeName format")
+	}
+	base.NodeName = n
+	s, ok := mm["Siz"].(float64)
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected Siz format")
+	}
+	base.Siz = uint64(s)
+	so, ok := mm["StartOffset"].(float64)
+	if !ok {
+		return nil, errors.New("GetRsNode(): unexpected StartOffset format")
+	}
+	base.StartOffset = uint64(so)
+	if mm["Links"] != nil {
+		li, ok := mm["Links"].([]interface{})
+		if !ok {
+			return nil, errors.New("GetRsNode(): unexpected Links format")
+		}
+		base.Links = li
+	} else {
+		base.Links = nil
+	}
+
+	switch base.NodeType {
+	case uio.DirNodeType:
+		return &uio.DirNode{
+			BaseNode: base,
+		}, nil
+	case uio.FileNodeType:
+		return &uio.FileNode{
+			BaseNode: base,
+		}, nil
+	case uio.SymlinkNodeType:
+		data := m["Data"].(string)
+		return &uio.SymlinkNode{
+			BaseNode: base,
+			Data:     data,
+		}, nil
+	default:
+		return nil, errors.New("GetRsNode(): unexpected NodeType. Possibly program error.")
+	}
+}
+
+func (it *rsIterator) Err() error {
+	return it.err
+}
+
+type rsFile struct {
+	uio.DagReader
+}
+
+func (f *rsFile) Size() (int64, error) {
+	return int64(f.DagReader.Size()), nil
+}
+
+func newReedSolomonDir(ctx context.Context, dserv ipld.DAGService, cid string, nd *uio.DirNode) (files.Directory, error) {
+	dir, err := uio.NewReedSolomonDirectoryFromNode(dserv, nd)
+	if err != nil {
+		return nil, err
+	}
+
+	size := nd.NodeSize()
+
+	return &rsDirectory{
+		ctx:       ctx,
+		dserv:     dserv,
+		dir:       *dir,
+		size:      int64(size),
+		cidString: cid,
+	}, nil
+}
+
+// NewReedSolomonDirectory returns files.Node for the root DAG node of a BTFS object in Reed-Solomon encoding.
+// This builder function is supposed to be called only one time for `btfs get` for a BTFS merkle DAG.
+func NewReedSolomonDirectory(ctx context.Context, root ipld.Node, dataNode ipld.Node, dserv ipld.DAGService, opts UnixfsFileOptions,
+	metaStruct *MetadataStruct) (files.Node, error) {
+	// Create reader and get root.
+	rsMeta := metaStruct.RsMeta
+	_, mrs, dataBuf, err := uio.NewReedSolomonDagReader(ctx, dataNode, dserv, rsMeta.NumData, rsMeta.NumParity,
+		rsMeta.FileSize, rsMeta.IsDir, opts.RepairShards)
+	if err != nil {
+		return nil, err
+	}
+
+	// Repair designated shards from opts.RepairShards.
+	err = checkAndRecoverShards(ctx, root, dserv, opts, mrs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set root directory node to `dirRoot`.
+	dirRoot := metaStruct.DirRoot
+	if dirRoot == nil {
+		return nil, errors.New("nil root node encountered")
+	}
+
+	// Create a Dag instance and set as context value.
+	cid := dataNode.Cid().String()
+	ctx = InitDag(ctx, dataBuf, cid)
+
+	// Create and return files.Dir
+	return newReedSolomonDir(ctx, dserv, cid, dirRoot)
+}
+
+func NewReedSolomonDag(dataBuf *bytes.Buffer, cid string) *ReedSolomonDag {
+	rsDagInstance := &ReedSolomonDag{
+		state:     ReedSolomonDagOff,
+		buff:      dataBuf,
+		offset:    0,
+		curFile:   nil,
+		cidString: cid,
+		lock:      sync.RWMutex{},
+	}
+
+	return rsDagInstance
+}
+
+func InitDag(ctx context.Context, dataBuf *bytes.Buffer, cid string) context.Context {
+	rsDagInstance := NewReedSolomonDag(dataBuf, cid)
+	rsDagInstance.state = ReedSolomonDagOpen
+
+	ctx = context.WithValue(ctx, cid, rsDagInstance)
+
+	return ctx
+}
+
+func GetDag(ctx context.Context, cid string) *ReedSolomonDag {
+	if v, ok := ctx.Value(cid).(*ReedSolomonDag); ok {
+		return v
+	}
+	return nil
+}
+
+// NewReedSolomonSugDirectory creates and returns a files.Dir with the given uio.Node.
+func NewReedSolomonSubDirectory(ctx context.Context, dserv ipld.DAGService, cid string, nd uio.Node) (files.Node, error) {
+	dNode, ok := nd.(*uio.DirNode)
+	if !ok {
+		return nil, errors.New("expected DirNode, but did not get it. Possibly a program error.")
+	}
+
+	return newReedSolomonDir(ctx, dserv, cid, dNode)
+}
+
+// NewReedSolomonFileUnderDirectory returns a files.Node for the given `nd` Node.
+// This functioon is called within the context of Reed-Solomon DAG for directory.
+// The given `nd` is a uio.FileNode and is used to create a reader.
+func NewReedSolomonFileUnderDirectory(ctx context.Context, dserv ipld.DAGService, cid string, nd uio.Node) (files.Node, error) {
+	// Locking is for synchronizing write access to rsDagInstance.offset.
+	// But rsDagInstance.offset may not be necessary. We use this field to verify the offset in `nd`.
+	rsDagInstance := GetDag(ctx, cid)
+	if rsDagInstance == nil {
+		return nil, errors.New("cannot find rsDagInstance from the current Context.context")
+	}
+	rsDagInstance.lock.Lock()
+	defer rsDagInstance.lock.Unlock()
+
+	rsDagInstance.state = ReedSolomonDagNext
+
+	fNode, ok := nd.(*uio.FileNode)
+	if !ok {
+		return nil, errors.New("expected FileNode, but did not get it. Possibly a program error.")
+	}
+
+	b := rsDagInstance.buff.Bytes()
+	offset := fNode.StartOffset
+	if rsDagInstance.offset != offset {
+		return nil, errors.New("offset from the given FileNode is invalid.")
+	}
+	newOffset := offset + uint64(fNode.NodeSize())
+	if newOffset > uint64(len(b)) {
+		return nil, errors.New("new offset is greater than buffer size.")
+	}
+	dr := bytes.NewReader(b[offset:newOffset])
+
+	rsDagInstance.offset = newOffset
+	return &rsFile{
+		DagReader: &uio.ReedSolomonDagReader{dr},
+	}, nil
+}
+
+func NewReedSolomonStandaloneFile(ctx context.Context, root ipld.Node, dataNode ipld.Node, dserv ipld.DAGService, opts UnixfsFileOptions,
+	metaStruct *MetadataStruct) (files.Node, error) {
+	rsMeta := metaStruct.RsMeta
+	dr, mrs, _, err := uio.NewReedSolomonDagReader(ctx, dataNode, dserv, rsMeta.NumData, rsMeta.NumParity,
+		rsMeta.FileSize, rsMeta.IsDir, opts.RepairShards)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkAndRecoverShards(ctx, root, dserv, opts, mrs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rsFile{
+		DagReader: dr,
+	}, nil
+}
+
+func checkAndRecoverShards(ctx context.Context, root ipld.Node, dserv ipld.DAGService, opts UnixfsFileOptions, mrs []io.Reader) error {
+	// Check which ones need recovery
+	var recovered []io.Reader
+	var rcids []cid.Cid
+	for i, mr := range mrs {
+		if mr != nil {
+			recovered = append(recovered, mr)
+			rcids = append(rcids, opts.RepairShards[i])
+		}
+	}
+	if len(recovered) > 0 {
+		err := addRecoveredShards(ctx, root, dserv, recovered, rcids)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addRecoveredShards mimics adding reed solomon shards anew according to the
+// original adder options.rootNode ipld.Node
+func addRecoveredShards(ctx context.Context, rootNode ipld.Node, ds ipld.DAGService,
+	recovered []io.Reader, rcids []cid.Cid) error {
+	b, err := uio.GetMetaDataFromDagRoot(ctx, rootNode, ds)
+	if err != nil {
+		return err
+	}
+
+	bMeta := util.GetMetadataElement(b)
+	sm, err := ihelper.GetOrDefaultSuperMeta(bMeta)
+	if err != nil {
+		return err
+	}
+
+	// Recover shard has a default size-based chunker
+	sc := fmt.Sprintf("size-%d", sm.ChunkSize)
+	for i, r := range recovered {
+		chnk, err := chunker.FromString(r, sc)
+		if err != nil {
+			return err
+		}
+
+		// Re-create (as much as possible) the original params
+		params := ihelper.DagBuilderParams{
+			Dagserv:   ds,
+			Maxlinks:  int(sm.MaxLinks),
+			ChunkSize: sm.ChunkSize,
+		}
+
+		db, err := params.New(chnk)
+		if err != nil {
+			return err
+		}
+
+		var sn ipld.Node // new shard root node
+		if sm.TrickleFormat {
+			sn, err = trickle.Layout(db)
+		} else {
+			sn, err = balanced.Layout(db)
+		}
+		if err != nil {
+			return err
+		}
+
+		if !rcids[i].Equals(sn.Cid()) {
+			return fmt.Errorf("recovered node [%s] does not match original [%s]",
+				sn.Cid().String(), rcids[i].String())
+		}
+	}
+
+	return nil
+}
+
+var _ files.Directory = &rsDirectory{}
+var _ files.File = &rsFile{}

--- a/file/reed_solomon_file.go
+++ b/file/reed_solomon_file.go
@@ -3,6 +3,7 @@ package unixfile
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/TRON-US/go-unixfs/importer/balanced"
@@ -177,40 +178,16 @@ func GetRsNode(l interface{}) (uio.Node, error) {
 		return nil, errors.New("GetRsNode(): unexpected Node format. Possibly program error.")
 	}
 
+	// Marshal mm and Unmarshal BaseNode to get BaseNode.
 	var base uio.BaseNode
-	typ, ok := mm["NodeType"].(float64)
-	if !ok {
-		return nil, errors.New("GetRsNode(): unexpected NodeType format")
+
+	b, err := json.Marshal(mm)
+	if err != nil {
+		return nil, err
 	}
-	base.NodeType = int(typ)
-	p, ok := mm["NodePath"].(string)
-	if !ok {
-		return nil, errors.New("GetRsNode(): unexpected NodePath format")
-	}
-	base.NodePath = p
-	n, ok := mm["NodeName"].(string)
-	if !ok {
-		return nil, errors.New("GetRsNode(): unexpected NodeName format")
-	}
-	base.NodeName = n
-	s, ok := mm["Siz"].(float64)
-	if !ok {
-		return nil, errors.New("GetRsNode(): unexpected Siz format")
-	}
-	base.Siz = uint64(s)
-	so, ok := mm["StartOffset"].(float64)
-	if !ok {
-		return nil, errors.New("GetRsNode(): unexpected StartOffset format")
-	}
-	base.StartOffset = uint64(so)
-	if mm["Links"] != nil {
-		li, ok := mm["Links"].([]interface{})
-		if !ok {
-			return nil, errors.New("GetRsNode(): unexpected Links format")
-		}
-		base.Links = li
-	} else {
-		base.Links = nil
+
+	if err := json.Unmarshal(b, &base); err != nil {
+		return nil, err
 	}
 
 	switch base.NodeType {

--- a/file/reed_solomon_file.go
+++ b/file/reed_solomon_file.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"sync"
+
 	"github.com/TRON-US/go-unixfs/importer/balanced"
 	ihelper "github.com/TRON-US/go-unixfs/importer/helpers"
 	"github.com/TRON-US/go-unixfs/importer/trickle"
 	"github.com/TRON-US/go-unixfs/util"
-	"io"
-	"sync"
 
 	uio "github.com/TRON-US/go-unixfs/io"
 
@@ -43,7 +44,7 @@ type ReedSolomonDag struct {
 type rsDirectory struct {
 	ctx       context.Context
 	dserv     ipld.DAGService
-	dir       uio.ReedSolomonDirectory
+	dir       *uio.ReedSolomonDirectory
 	size      int64
 	cidString string
 }
@@ -233,7 +234,7 @@ func newReedSolomonDir(ctx context.Context, dserv ipld.DAGService, cid string, n
 	return &rsDirectory{
 		ctx:       ctx,
 		dserv:     dserv,
-		dir:       *dir,
+		dir:       dir,
 		size:      int64(size),
 		cidString: cid,
 	}, nil
@@ -438,6 +439,3 @@ func addRecoveredShards(ctx context.Context, rootNode ipld.Node, ds ipld.DAGServ
 
 	return nil
 }
-
-var _ files.Directory = &rsDirectory{}
-var _ files.File = &rsFile{}

--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -264,7 +264,7 @@ func ObtainMetadataFromDag(ctx context.Context, metaNode ipld.Node, dserv ipld.N
 	}
 
 	// Split the buf into two byte arrays.
-	ts := strings.SplitN(string(buf), "},{", 2)
+	ts := strings.SplitN(string(buf), "}#{", 2)
 	metaBuf := append([]byte(ts[0]), '}')
 	treeBuf := append([]byte("{"), []byte(ts[1])...)
 

--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
-
 	ft "github.com/TRON-US/go-unixfs"
 	uio "github.com/TRON-US/go-unixfs/io"
 	"github.com/TRON-US/go-unixfs/util"
@@ -264,9 +262,10 @@ func ObtainMetadataFromDag(ctx context.Context, metaNode ipld.Node, dserv ipld.N
 	}
 
 	// Split the buf into two byte arrays.
-	ts := strings.SplitN(string(buf), "}#{", 2)
-	metaBuf := append([]byte(ts[0]), '}')
-	treeBuf := append([]byte("{"), []byte(ts[1])...)
+	metaBuf, treeBuf, err := util.GetMetadataList(buf)
+	if err != nil {
+		return nil, err
+	}
 
 	// Read RsMetaMap
 	var rsMeta chunker.RsMetaMap

--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -42,7 +42,7 @@ func TestUnixFsFileRead(t *testing.T) {
 }
 
 func TestUnixFsFileReadWithMetadata(t *testing.T) {
-	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]},{}`)
+	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}#{}`)
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
 		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMeta, 512, nil))
@@ -126,7 +126,7 @@ func TestUnixFsFileReedSolomonRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rsMeta = append(append(rsMeta[:len(rsMeta)], ','), []byte("{}")...)
+	rsMeta = append(append(rsMeta[:len(rsMeta)], '#'), []byte("{}")...)
 	err = testu.ArrComp(rsMeta, outbuf)
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func TestUnixFsFileReedSolomonRead(t *testing.T) {
 }
 
 func TestUnixFsFileReedSolomonMetadataRead(t *testing.T) {
-	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]},{}`)
+	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}#{}`)
 	dserv := testu.GetDAGServ()
 
 	rsOpts, rsMeta := testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity,

--- a/file/unixfile_test.go
+++ b/file/unixfile_test.go
@@ -5,11 +5,10 @@ import (
 	"io/ioutil"
 	"testing"
 
+	files "github.com/TRON-US/go-btfs-files"
 	"github.com/TRON-US/go-unixfs/importer/helpers"
 	uio "github.com/TRON-US/go-unixfs/io"
 	testu "github.com/TRON-US/go-unixfs/test"
-
-	files "github.com/TRON-US/go-btfs-files"
 )
 
 func TestUnixFsFileRead(t *testing.T) {
@@ -43,7 +42,7 @@ func TestUnixFsFileRead(t *testing.T) {
 }
 
 func TestUnixFsFileReadWithMetadata(t *testing.T) {
-	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}`)
+	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]},{}`)
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024,
 		testu.UseBalancedWithMetadata(helpers.DefaultLinksPerBlock, inputMeta, 512, nil))
@@ -127,6 +126,7 @@ func TestUnixFsFileReedSolomonRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rsMeta = append(append(rsMeta[:len(rsMeta)], ','), []byte("{}")...)
 	err = testu.ArrComp(rsMeta, outbuf)
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func TestUnixFsFileReedSolomonRead(t *testing.T) {
 }
 
 func TestUnixFsFileReedSolomonMetadataRead(t *testing.T) {
-	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]}`)
+	inputMeta := []byte(`{"hello":1,"world":["33","11","22"]},{}`)
 	dserv := testu.GetDAGServ()
 
 	rsOpts, rsMeta := testu.UseReedSolomon(testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/TRON-US/go-unixfs
 
 require (
 	github.com/Stebalien/go-bitfield v0.0.1
-	github.com/TRON-US/go-btfs-chunker v0.2.5
+	github.com/TRON-US/go-btfs-chunker v0.2.6
 	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/gogo/protobuf v1.2.1
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
@@ -19,9 +19,6 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830
-	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 )
 
 go 1.13
-
-replace github.com/TRON-US/go-btfs-chunker => ../go-btfs-chunker

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,9 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830
+	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 )
 
 go 1.13
+
+replace github.com/TRON-US/go-btfs-chunker => ../go-btfs-chunker

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOv
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
-github.com/TRON-US/go-btfs-chunker v0.2.5 h1:mU4iu2jYs89PtIO5vnJwqZHUgx/gwV0z8RFHmZNDS1U=
-github.com/TRON-US/go-btfs-chunker v0.2.5/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
+github.com/TRON-US/go-btfs-chunker v0.2.6 h1:SPeUEMGSHNQyBSTU50nYBdaJA36CXPzQRtceB9nI4x8=
+github.com/TRON-US/go-btfs-chunker v0.2.6/go.mod h1:Wj0oyybAWtu5lpcAc90QQ3bhJ14JRXD50PqxP25wmnI=
 github.com/TRON-US/go-btfs-files v0.1.1 h1:GuDIiWDM66bfhfxJy8+dBL4Cfbcp3iBp7pgHpKKCw8k=
 github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=

--- a/io/reed_solomon_dagreader_test.go
+++ b/io/reed_solomon_dagreader_test.go
@@ -22,8 +22,8 @@ func TestReedSolomonRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reader, _, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
-		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)), nil)
+	reader, _, _, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
+		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)), false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,8 +58,8 @@ func TestReedSolomonWithMetadataRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reader, _, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
-		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)), nil)
+	reader, _, _, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
+		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)), false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,8 +105,8 @@ func TestReedSolomonReadRepair(t *testing.T) {
 	// Randomly remove some sharded nodes and repair the missing
 	rsnode, removed, removedIndex := testu.RandomRemoveNodes(t, ctx, node, dserv, 10)
 
-	reader, repaired, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
-		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)), removed)
+	reader, repaired, _, err := NewReedSolomonDagReader(ctx, rsnode, dserv,
+		testu.TestRsDefaultNumData, testu.TestRsDefaultNumParity, uint64(len(inbuf)), false, removed)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/io/reed_solomon_directory.go
+++ b/io/reed_solomon_directory.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"context"
+	"errors"
 	files "github.com/TRON-US/go-btfs-files"
 	ipld "github.com/ipfs/go-ipld-format"
 )
@@ -61,6 +62,9 @@ func (n *BaseNode) NodeSize() int64 {
 
 // ForEachLink implements the `Directory` interface.
 func (d *ReedSolomonDirectory) ForEachLink(ctx context.Context, f func(interface{}) error) error {
+	if d.DNode == nil {
+		return errors.New("nil d.Dnode encountered")
+	}
 	for _, l := range d.DNode.Links {
 		if err := f(l); err != nil {
 			return err
@@ -71,14 +75,17 @@ func (d *ReedSolomonDirectory) ForEachLink(ctx context.Context, f func(interface
 
 // Links implements the `Directory` interface.
 func (d *ReedSolomonDirectory) Links(ctx context.Context) []interface{} {
+	if d.DNode == nil {
+		return nil
+	}
 	return d.DNode.Links
 }
 
 func NewReedSolomonDirectory(dserv ipld.DAGService) *ReedSolomonDirectory {
-	dir := new(ReedSolomonDirectory)
-	dir.DNode = nil
-	dir.dserv = dserv
-	return dir
+	return &ReedSolomonDirectory{
+		DNode: nil,
+		dserv: dserv,
+	}
 }
 
 // NewReedSolomonDirectoryFromNode loads a ReedSolomon directory

--- a/io/reed_solomon_directory.go
+++ b/io/reed_solomon_directory.go
@@ -1,0 +1,91 @@
+package io
+
+import (
+	"context"
+	files "github.com/TRON-US/go-btfs-files"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+type Node interface {
+	Path() string
+	NodeSize() int64
+	Name() string
+}
+
+const (
+	DirNodeType     = 1
+	FileNodeType    = 2
+	SymlinkNodeType = 3
+)
+
+type BaseNode struct {
+	NodeType    int
+	NodePath    string
+	NodeName    string
+	Siz         uint64
+	StartOffset uint64
+	Links       []interface{}
+}
+
+// files.Directory is input directory
+type DirNode struct {
+	BaseNode        `json:"BaseNode"`
+	files.Directory `json:"files.Directory"`
+}
+type FileNode struct {
+	BaseNode `json:"BaseNode"`
+	//files.File `json:"files.File"`
+}
+type SymlinkNode struct {
+	BaseNode `json:"BaseNode"`
+	Data     string
+	//files.Symlink `json:"files.Symlink"`
+}
+
+// ReedSolomonDirectory is the implementation of `Directory for Reed-Solomon
+// BTFS file. All the entries are stored in a single node.
+type ReedSolomonDirectory struct {
+	DNode *DirNode
+	dserv ipld.DAGService
+}
+
+func (n *BaseNode) Path() string {
+	return n.NodePath
+}
+func (n *BaseNode) Name() string {
+	return n.NodeName
+}
+func (n *BaseNode) NodeSize() int64 {
+	return int64(n.Siz)
+}
+
+// ForEachLink implements the `Directory` interface.
+func (d *ReedSolomonDirectory) ForEachLink(ctx context.Context, f func(interface{}) error) error {
+	for _, l := range d.DNode.Links {
+		if err := f(l); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Links implements the `Directory` interface.
+func (d *ReedSolomonDirectory) Links(ctx context.Context) []interface{} {
+	return d.DNode.Links
+}
+
+func NewReedSolomonDirectory(dserv ipld.DAGService) *ReedSolomonDirectory {
+	dir := new(ReedSolomonDirectory)
+	dir.DNode = nil
+	dir.dserv = dserv
+	return dir
+}
+
+// NewReedSolomonDirectoryFromNode loads a ReedSolomon directory
+// from the given DirNode and DAGService.
+func NewReedSolomonDirectoryFromNode(dserv ipld.DAGService, dn *DirNode) (*ReedSolomonDirectory, error) {
+	dir := new(ReedSolomonDirectory)
+	dir.DNode = dn
+	dir.dserv = dserv
+	return dir, nil
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -106,7 +106,7 @@ func ExtendMetaBytes(existing []byte, extended []byte) []byte {
 	} else {
 		returnBytes = extended
 	}
-	returnBytes = append(append(returnBytes[:len(returnBytes)], ','), []byte("{}")...)
+	returnBytes = append(append(returnBytes[:len(returnBytes)], '#'), []byte("{}")...)
 	return returnBytes
 }
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -95,16 +95,19 @@ func ReedSolomonMetaBytes(numData, numParity, fileSize uint64) []byte {
 }
 
 func ExtendMetaBytes(existing []byte, extended []byte) []byte {
+	var returnBytes []byte
 	if existing != nil {
 		// Splice two meta json objects
 		if extended != nil {
-			return append(append(existing[:len(existing)-1], ','), extended[1:]...)
+			returnBytes = append(append(existing[:len(existing)-1], ','), extended[1:]...)
 		} else {
-			return existing
+			returnBytes = existing
 		}
 	} else {
-		return extended
+		returnBytes = extended
 	}
+	returnBytes = append(append(returnBytes[:len(returnBytes)], ','), []byte("{}")...)
+	return returnBytes
 }
 
 func UseReedSolomon(numData, numParity, fileSize uint64, mdata []byte, chkSize uint64) (NodeOpts, []byte) {

--- a/util/metautils.go
+++ b/util/metautils.go
@@ -107,9 +107,9 @@ func CreateMetadataList(metaBytes []byte, dirTreeBytes []byte) []byte {
 		metaBytes = []byte("{}")
 	}
 	if dirTreeBytes != nil {
-		metaBytes = append(append(metaBytes[:len(metaBytes)], ','), dirTreeBytes[:]...)
+		metaBytes = append(append(metaBytes[:len(metaBytes)], '#'), dirTreeBytes[:]...)
 	} else {
-		metaBytes = append(append(metaBytes[:len(metaBytes)], ','), []byte("{}")...)
+		metaBytes = append(append(metaBytes[:len(metaBytes)], '#'), []byte("{}")...)
 	}
 
 	return metaBytes
@@ -119,7 +119,7 @@ func CreateMetadataList(metaBytes []byte, dirTreeBytes []byte) []byte {
 // into two byte arrays in JSON format.
 // Note that chunker.RsMetaMap.IsDir indicates or true when the second array has contents.
 func GetMetadataList(bytes []byte) ([]byte, []byte, error) {
-	ts := strings.SplitN(string(bytes), "},{", 2)
+	ts := strings.SplitN(string(bytes), "}#{", 2)
 
 	metaBuf := append([]byte(ts[0]), '}')
 	treeBuf := append([]byte("{"), []byte(ts[1])...)

--- a/util/metautils.go
+++ b/util/metautils.go
@@ -1,0 +1,142 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	ft "github.com/TRON-US/go-unixfs"
+	uio "github.com/TRON-US/go-unixfs/io"
+
+	ipld "github.com/ipfs/go-ipld-format"
+	mdag "github.com/ipfs/go-merkledag"
+)
+
+// checkAndSplitMetadata returns both data root node and metadata root node if exists from
+// the DAG topped by the given 'nd'.
+// Case #1: if 'nd' is dummy root with metadata root node and user data root node being children,
+//    return [the second data root child node, the first metadata root child node, nil].
+// Case #2: if 'nd' is metadata and the given `meta` is true, return [nil, nd, nil]. Otherwise return error.
+// Case #3: if 'nd' is user data, return ['nd', nil, nil].
+func CheckAndSplitMetadata(ctx context.Context, nd ipld.Node, ds ipld.DAGService, meta bool) (ipld.Node, ipld.Node, error) {
+	n := nd.(*mdag.ProtoNode)
+
+	fsType, err := ft.GetFSType(n)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if ft.TTokenMeta == fsType {
+		if meta {
+			return nil, nd, nil
+		} else {
+			return nil, nil, ft.ErrMetadataAccessDenied
+		}
+	}
+
+	// Return user data and metadata if first child is of type TTokenMeta.
+	if nd.Links() != nil && len(nd.Links()) >= 2 {
+		children, err := ft.GetChildrenForDagWithMeta(ctx, nd, ds)
+		if err != nil {
+			return nil, nil, err
+		}
+		if children == nil {
+			return nd, nil, nil
+		}
+		return children.DataNode, children.MetaNode, nil
+	}
+
+	return nd, nil, nil
+}
+
+func ReadMetadataElementFromDag(ctx context.Context, root ipld.Node, ds ipld.DAGService, meta bool) ([]byte, error) {
+	b, _, err := ReadMetadataListFromDag(ctx, root, ds, meta)
+	return b, err
+}
+
+func ReadMetadataListFromDag(ctx context.Context, root ipld.Node, ds ipld.DAGService, meta bool) ([]byte, []byte, error) {
+	nd, ok := root.(*mdag.ProtoNode)
+	if !ok {
+		return nil, nil, errors.New("Expected protobuf Merkle DAG node")
+	}
+	fsn, err := ft.FSNodeFromBytes(nd.Data())
+	if err != nil {
+		return nil, nil, err
+	}
+	typ := fsn.Type()
+	if typ != ft.TFile && typ != ft.TDirectory && typ != ft.TTokenMeta {
+		return nil, nil, errors.New("unexpected node type")
+	}
+
+	_, mnode, err := CheckAndSplitMetadata(ctx, root, ds, meta)
+	if err != nil {
+		return nil, nil, err
+	}
+	if mnode == nil {
+		return nil, nil, nil
+	}
+
+	r, err := uio.NewDagReader(ctx, mnode, ds)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b := make([]byte, r.Size())
+	_, err = r.CtxReadFull(ctx, b)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return GetMetadataList(b)
+}
+
+// CreateMetadataList join the given two byte array element into a final list
+// format as BTFS metadata.
+// 1. Append the above `dirTreeBytes` byte array to metaBytes so that
+//   the final encoded output can ebable strings.SplitAfterN(encodedOutput, "},{", 2) to have
+//   two strings, to be processed separately with json.Unmarshal().
+// 2. Ensure metaBytes has two sections, each enclosed within curly bracket pair. E.g., `{"price":11.0},{}`.
+//   This will make the encoder task easy.
+// The precondition is to pass nil to `metaBytes` if no value exist for regular metadata,
+// nil to `dirTreeBytes` for directoy tree bytes in case of Reed-Solomon directory inpuyt,
+func CreateMetadataList(metaBytes []byte, dirTreeBytes []byte) []byte {
+	if metaBytes == nil && dirTreeBytes == nil {
+		return nil
+	}
+	if metaBytes == nil {
+		metaBytes = []byte("{}")
+	}
+	if dirTreeBytes != nil {
+		metaBytes = append(append(metaBytes[:len(metaBytes)], ','), dirTreeBytes[:]...)
+	} else {
+		metaBytes = append(append(metaBytes[:len(metaBytes)], ','), []byte("{}")...)
+	}
+
+	return metaBytes
+}
+
+// GetMetadataSList splits the given encoded metadata `bytes`
+// into two byte arrays in JSON format.
+// Note that chunker.RsMetaMap.IsDir indicates or true when the second array has contents.
+func GetMetadataList(bytes []byte) ([]byte, []byte, error) {
+	ts := strings.SplitN(string(bytes), "},{", 2)
+
+	metaBuf := append([]byte(ts[0]), '}')
+	treeBuf := append([]byte("{"), []byte(ts[1])...)
+
+	return metaBuf, treeBuf, nil
+}
+
+func GetMetadataElement(bytes []byte) []byte {
+	b, _, _ := GetMetadataList(bytes)
+	return b
+}
+
+func GetSerializedDirectoryElement(bytes []byte) []byte {
+	_, b, _ := GetMetadataList(bytes)
+	return b
+}
+
+func IsMetadataEmpty(b []byte) bool {
+	return string(b) == "{}"
+}

--- a/util/utils.go
+++ b/util/utils.go
@@ -1,17 +1,5 @@
 package util
 
-import (
-	"context"
-	"errors"
-
-	ft "github.com/TRON-US/go-unixfs"
-	ufile "github.com/TRON-US/go-unixfs/file"
-	uio "github.com/TRON-US/go-unixfs/io"
-
-	ipld "github.com/ipfs/go-ipld-format"
-	mdag "github.com/ipfs/go-merkledag"
-)
-
 // Intersects returns true if the given two maps intersect.
 func Intersects(m map[string]interface{}, inputM map[string]interface{}) bool {
 	for k, _ := range inputM {
@@ -50,40 +38,4 @@ func EqualKeySets(m map[string]interface{}, inputKeys []string) bool {
 	}
 
 	return true
-}
-
-func ReadMetadataBytes(ctx context.Context, root ipld.Node, ds ipld.DAGService, meta bool) ([]byte, error) {
-	nd, ok := root.(*mdag.ProtoNode)
-	if !ok {
-		return nil, errors.New("Expected protobuf Merkle DAG node")
-	}
-	fsn, err := ft.FSNodeFromBytes(nd.Data())
-	if err != nil {
-		return nil, err
-	}
-	typ := fsn.Type()
-	if typ != ft.TFile && typ != ft.TDirectory && typ != ft.TTokenMeta {
-		return nil, errors.New("unexpected node type")
-	}
-
-	_, mnode, err := ufile.CheckAndSplitMetadata(ctx, root, ds, meta)
-	if err != nil {
-		return nil, err
-	}
-	if mnode == nil {
-		return nil, nil
-	}
-
-	r, err := uio.NewDagReader(ctx, mnode, ds)
-	if err != nil {
-		return nil, err
-	}
-
-	b := make([]byte, r.Size())
-	_, err = r.CtxReadFull(ctx, b)
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
 }


### PR DESCRIPTION
…eplication unit
This is go-unixfs changes for BTFS-1191.
In short, the changes are for supporting the feature of 
"Reed Solomon based operations on directory object in one replication unit".

1. Added file/reed_solomon_file.go b/file/reed_solomon_file.go
   - Added Reed-Solomon DAG, directory, file and directory iterator API to support calls from go-btfs-files.
2. Modified file/unixfile.go
   - Added MetadataStruct to include previous RsMetaMap and a newly added tree metadata 
     (for Reed-Solomon DAG)
3. Added io/reed_solomon_directory.go
   - Added ReedSolomonDirectory and Node and its implementation node types for Reed-Solomon DAG tree.
4. Modified mod/dagmodifier.go 
   - Modified `MetaDagModifier` methods to reflect on the changes in token metadata structure
     by the introduction of MetaStruct and directory DAG tree(for Reed-Solomon directory).
5. Added util/metautils.go
   - Added supporting methods for the functionality of "Reed Solomon based operations on directory object 
      in one replication unit".
6. Misc: minor changes for supporting the feature.