### PR TITLE
BTFS-1191-2: fix unit test failure in go-btfs

### DIFF
--- a/mod/dagmodifier.go
+++ b/mod/dagmodifier.go
@@ -747,7 +747,7 @@ func (mdm *MetaDagModifier) AddMetadata(root ipld.Node, metadata []byte) (ipld.N
 			// Combine two JSON format byte arrays. E.g.,
 			// `{"price":12.22} + `{"number":1234}` -> `{"price":12.22,"number":1234}`
 			metadata[0] = ','
-			metadata = append(append(metadata[:], ','), encodedTree[:]...)
+			metadata = append(append(metadata[:], '#'), encodedTree[:]...)
 			offset := int(fileSize) - treeSize - 2
 			nmod, err := mdm.WriteAt(metadata, int64(offset))
 			if err != nil {


### PR DESCRIPTION
small change to fix go-btfs unit test failure.